### PR TITLE
chore: Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -31,7 +31,7 @@ jobs:
         run: pytest tests/ -v --cov=custom_components/cuboai --cov-report=xml
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         if: matrix.python-version == '3.12'
         with:
           files: ./coverage.xml
@@ -41,7 +41,7 @@ jobs:
     name: Validate Integration
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: HACS Validation
         uses: hacs/action@main
@@ -57,10 +57,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -70,7 +70,7 @@ jobs:
           cat CHANGELOG.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           body_path: CHANGELOG.md
           generate_release_notes: false


### PR DESCRIPTION
## Summary
Combined update of all GitHub Actions to their latest major versions.

### Changes
- \ctions/checkout\ v4  v6
- \ctions/setup-python\ v5  v6  
- \codecov/codecov-action\ v4  v5
- \softprops/action-gh-release\ v1  v2

### Why
All updates move to Node.js 24 runtime for improved performance and security. These are safe, routine dependency updates from official/trusted sources.

### Notes
This PR replaces the following Dependabot PRs which can be closed:
- #17 (softprops/action-gh-release)
- #18 (codecov/codecov-action)
- #19 (actions/setup-python)
- #20 (actions/checkout)