### PR TITLE
fix: Release workflow respects branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,18 +29,15 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Releasing version: $VERSION"
 
-      - name: Update version in manifest.json
+      - name: Verify manifest version matches tag
         run: |
-          sed -i 's/"version": "[^"]*"/"version": "${{ steps.version.outputs.version }}"/' custom_components/cuboai/manifest.json
-          cat custom_components/cuboai/manifest.json
-
-      - name: Commit version bump
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add custom_components/cuboai/manifest.json
-          git commit -m "chore: Bump version to ${{ steps.version.outputs.version }}" || echo "No changes to commit"
-          git push origin HEAD:main
+          MANIFEST_VERSION=$(grep -oP '"version":\s*"\K[^"]+' custom_components/cuboai/manifest.json)
+          TAG_VERSION=${{ steps.version.outputs.version }}
+          echo "Manifest version: $MANIFEST_VERSION"
+          echo "Tag version: $TAG_VERSION"
+          if [ "$MANIFEST_VERSION" != "$TAG_VERSION" ]; then
+            echo "::warning::Manifest version ($MANIFEST_VERSION) does not match tag version ($TAG_VERSION). Update manifest.json before tagging."
+          fi
 
       - name: Generate changelog
         id: changelog

--- a/custom_components/cuboai/manifest.json
+++ b/custom_components/cuboai/manifest.json
@@ -11,5 +11,5 @@
         "requests",
         "pyjwt"
     ],
-    "version": "1.0.8"
+    "version": "1.1.1"
 }


### PR DESCRIPTION
## Problem
Release workflow was failing because it tried to push version bump directly to main, which is blocked by branch protection rules requiring PRs and signed commits.

## Solution
- Remove the \Update version in manifest.json\ and \Commit version bump\ steps that push to main
- Add a \Verify manifest version matches tag\ step that warns if versions don't match
- **Going forward**: Update \manifest.json\ version in the PR before creating a release tag

## Also included
- Bumps \manifest.json\ to v1.1.1 (matching the tag we just pushed)

## New Release Process
1. Update version in \manifest.json\ as part of your PR
2. Merge PR to main
3. Create and push tag: \git tag v1.x.x && git push origin v1.x.x\
4. Workflow creates GitHub Release with changelog