### PR TITLE
feat: Migrate from warrant to pycognito

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -120,8 +120,8 @@ Access via `entry.data` or `entry.options`:
 - Debug log: `/config/cuboai_auth.log`
 
 ### Dependencies
-- `boto3` + `warrant==0.6.1` for Cognito SRP (warrant auto-installed at runtime)
-- `pyjwt` for ID token decoding
+- `boto3` for AWS Cognito client
+- `pycognito` for Cognito SRP authentication
 - `requests` for HTTP calls
 
 ### Cognito Auth Constants

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you found this project helpful, you can [buy me a coffee](https://coff.ee/nir
 - Sensor for **subscription status** (Premium, trial, grace period, etc.)
 - Sensor for **camera online/offline state**
 - Support for multiple CuboAI cameras (multi-instance integration)
-- Easy authentication with CuboAI (uses warrant for SRP/AWS Cognito)
+- Easy authentication with CuboAI (uses pycognito for SRP/AWS Cognito)
 - All data stays local—no cloud polling from Home Assistant servers
 
 ---

--- a/custom_components/cuboai/api/cuboai_functions.py
+++ b/custom_components/cuboai/api/cuboai_functions.py
@@ -1,16 +1,14 @@
 import base64
 import hashlib
 import hmac
-import importlib
 import json
 import os
-import subprocess
-import sys
 import time
 
 import boto3
 import jwt
 import requests
+from pycognito.aws_srp import AWSSRP
 
 from custom_components.cuboai.utils import log_to_file
 
@@ -111,63 +109,6 @@ def load_refresh_token():
 
 
 # --- Cognito SRP Utilities ---
-def ensure_warrant_installed():
-    """
-    Ensure 'warrant' is installed and importable in Home Assistant's /config/deps path.
-    If missing, automatically installs warrant==0.6.1 into the detected deps path.
-    Creates the folder if it does not exist.
-    """
-    # Detect Python version
-    py_version = f"python{sys.version_info.major}.{sys.version_info.minor}"
-    deps_root = f"/config/deps/lib/{py_version}"
-    site_packages = os.path.join(deps_root, "site-packages")
-
-    # Create folder if missing
-    if not os.path.exists(site_packages):
-        try:
-            os.makedirs(site_packages, exist_ok=True)
-            log_to_file(f"Created missing folder: {site_packages}")
-        except Exception as e:
-            raise ImportError(f"Failed to create deps folder {site_packages}: {e}")
-
-    # Ensure path is in sys.path (insert at beginning so it has priority)
-    if site_packages not in sys.path:
-        sys.path.insert(0, site_packages)
-
-    # Try importing
-    try:
-        from warrant.aws_srp import AWSSRP  # noqa: F401
-
-        return True
-    except ImportError:
-        try:
-            log_to_file("warrant not found, attempting auto-install warrant==0.6.1...")
-            subprocess.check_call(
-                [
-                    sys.executable,
-                    "-m",
-                    "pip",
-                    "install",
-                    "--no-cache-dir",
-                    "--upgrade",
-                    "--no-deps",
-                    "--target",
-                    site_packages,
-                    "warrant==0.6.1",
-                ]
-            )
-            importlib.invalidate_caches()
-            from warrant.aws_srp import AWSSRP  # noqa: F401
-
-            log_to_file("warrant successfully installed.")
-            return True
-        except Exception as e:
-            raise ImportError(f"Failed to auto-install warrant==0.6.1 into {site_packages}: {e}")
-
-
-# Make sure warrant is available before import
-ensure_warrant_installed()
-from warrant.aws_srp import AWSSRP
 
 
 def get_secret_hash(username, client_id, client_secret):

--- a/custom_components/cuboai/manifest.json
+++ b/custom_components/cuboai/manifest.json
@@ -8,8 +8,8 @@
     "issue_tracker": "https://github.com/niruse/cuboai/issues",
     "requirements": [
         "boto3>=1.26.0",
-        "requests",
-        "pyjwt"
+        "pycognito>=2024.5.1",
+        "requests"
     ],
-    "version": "1.1.2"
+    "version": "1.2.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ ignore = [
     "B008",   # do not perform function calls in argument defaults
     "B905",   # zip without explicit strict
     "W191",   # indentation contains tabs
-    "E402",   # module level import not at top (needed for test mocking and warrant install)
+    "E402",   # module level import not at top (needed for test mocking)
     "B904",   # raise from in except (verbose for simple reraise)
 ]
 


### PR DESCRIPTION
## Summary
Migrate from the unmaintained \warrant\ library to the actively maintained \pycognito\ for AWS Cognito SRP authentication. This eliminates the need for runtime pip installation and follows Home Assistant guidelines for dependency management.

## Changes
- Replace \warrant==0.6.1\ with \pycognito>=2024.5.1\ in manifest.json
- Remove \ensure_warrant_installed()\ function (~60 lines of runtime pip install code)
- Remove \pyjwt\ from manifest (pycognito includes it via its dependencies)
- Update imports to use \pycognito.aws_srp.AWSSRP\
- Clean up unused imports (\subprocess\, \importlib\, \sys\)
- Update documentation to reflect pycognito usage
- Bump version to 1.2.0

## Benefits
- **No more runtime pip install** - Dependencies properly declared in manifest, HA handles installation
- **Follows HA guidelines** - Custom components should not run pip at runtime
- **Easier testing** - No warrant install side effects blocking module imports
- **Actively maintained** - pycognito is maintained by Pascal Vizeli (HA core team member)
- **Cleaner code** - Removed 60 lines of workaround code

## Testing
- [x] All existing tests pass
- [x] Ruff linting passes
- [ ] CI will verify hassfest/HACS validation

Closes #31