### PR TITLE
Number of Events Retained as Configurable Value

### DIFF
--- a/custom_components/cuboai/config_flow.py
+++ b/custom_components/cuboai/config_flow.py
@@ -3,6 +3,7 @@ import random
 
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.core import callback
 
 from .api import cuboai_functions as api
 from .const import DOMAIN
@@ -245,6 +246,7 @@ class CuboAIConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     @staticmethod
+    @callback
     def async_get_options_flow(config_entry):
         return CuboAIOptionsFlowHandler(config_entry)
 
@@ -255,7 +257,7 @@ class CuboAIOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input=None):
         if user_input is not None:
-            return self.async_create_entry(title="", data={"download_images": user_input.get("download_images", True)})
+            return self.async_create_entry(title="", data=user_input)
 
         return self.async_show_form(
             step_id="init",
@@ -266,7 +268,13 @@ class CuboAIOptionsFlowHandler(config_entries.OptionsFlow):
                         default=self.config_entry.options.get(
                             "download_images", self.config_entry.data.get("download_images", True)
                         ),
-                    ): bool
+                    ): bool,
+                    vol.Optional(
+                        "alerts_count",
+                        default=self.config_entry.options.get(
+                            "alerts_count", self.config_entry.data.get("alerts_count", 5)
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=50)),
                 }
             ),
         )

--- a/custom_components/cuboai/config_flow.py
+++ b/custom_components/cuboai/config_flow.py
@@ -253,6 +253,7 @@ class CuboAIConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 class CuboAIOptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry):
+        super().__init__()
         self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
@@ -275,6 +276,12 @@ class CuboAIOptionsFlowHandler(config_entries.OptionsFlow):
                             "alerts_count", self.config_entry.data.get("alerts_count", 5)
                         ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=1, max=50)),
+                    vol.Optional(
+                        "hours_back",
+                        default=self.config_entry.options.get(
+                            "hours_back", self.config_entry.data.get("hours_back", 12)
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=72)),
                 }
             ),
         )

--- a/custom_components/cuboai/sensor.py
+++ b/custom_components/cuboai/sensor.py
@@ -330,8 +330,8 @@ class CuboLastAlertSensor(CuboBaseSensor):
 
     # ---------- Update logic ----------
 
-    def _cleanup_old_images(self):
-        """Cleanup old images, keeping only the latest 5 per device.
+    def _cleanup_old_images(self, limit):
+        """Cleanup old images, keeping only the latest N per device.
 
         This is a blocking operation and should be run via executor.
         """
@@ -342,7 +342,7 @@ class CuboLastAlertSensor(CuboBaseSensor):
             key=lambda f: f.stat().st_mtime,
             reverse=True,
         )
-        for old_file in files[5:]:
+        for old_file in files[limit:]:
             try:
                 old_file.unlink(missing_ok=True)
             except Exception:
@@ -444,7 +444,7 @@ class CuboLastAlertSensor(CuboBaseSensor):
                 if self.download_images:
                     try:
                         # Run cleanup in executor since it uses blocking pathlib
-                        await self.hass.async_add_executor_job(self._cleanup_old_images)
+                        await self.hass.async_add_executor_job(self._cleanup_old_images, self.max_alerts)
                     except Exception as e:
                         log_to_file(f"[CuboLastAlertSensor] Error cleaning images: {e}")
 


### PR DESCRIPTION
Made it so that the `download_images`, `alerts_count`, and `hours_back` variables are configurable during integration setup.  Currently, `alerts_count` is hard-coded to 5.