### PR TITLE
Fix silently-wrong camera state, plus vendored-engine parity

### DIFF
--- a/custom_components/cuboai/coordinator.py
+++ b/custom_components/cuboai/coordinator.py
@@ -143,6 +143,22 @@ def _fetch_local_data(
                             log_to_file(f"Failed to get temp_humidity: {e}")
 
                         try:
+                            # Night-light brightness (percent). The camera reports it on
+                            # GET_LIGHT_STYLE @24; nothing was reading it, so
+                            # `local["brightness"]` was never populated at all — the
+                            # Night Light Brightness number fell back to a hardcoded 100
+                            # regardless of the camera, and the light entity reported no
+                            # brightness despite advertising ColorMode.BRIGHTNESS.
+                            from .tutk.cuboai_messages import build_get_light_style, parse_light_style
+
+                            _rt, _raw = sess.ioctl(*build_get_light_style())
+                            _style = parse_light_style(_raw)
+                            if _style.get("brightness") is not None:
+                                data["brightness"] = _style["brightness"]
+                        except Exception as e:
+                            log_to_file(f"Failed to get light style: {e}")
+
+                        try:
                             data["sleep_mode_on"] = client.get_sleep_mode().get("enabled")
                         except Exception as e:
                             log_to_file(f"Failed to get sleep_mode: {e}")

--- a/custom_components/cuboai/coordinator.py
+++ b/custom_components/cuboai/coordinator.py
@@ -253,9 +253,24 @@ def _fetch_local_data(
                         try:
                             sched = client.get_lullaby_schedule()
                             data["lullaby_volume"] = sched.volume
+                            # The camera's ACTUAL sleep timer, echoed on this same
+                            # response (offset 8): 0 = repeat forever, 1800 = 30 min,
+                            # 3600 = 60 min. It was being read and thrown away, so the
+                            # Lullaby Timer number had nothing to reconcile against and
+                            # showed only whatever Home Assistant last set locally —
+                            # "30 minutes" while the camera was actually on repeat.
+                            data["lullaby_timer_mode"] = sched.timer_mode
+                            data["lullaby_timer_name"] = sched.timer_name
+                            data["lullaby_timer_minutes"] = (
+                                sched.timer_mode // 60 if sched.timer_mode else 0
+                            )
                         except Exception as e:
+                            # Do NOT invent a volume here. The previous fallback wrote a
+                            # hardcoded 50, which the merge in _fetch_all then treated as
+                            # a real reading and carried forward — so a failed schedule
+                            # read silently reported the wrong volume instead of keeping
+                            # the last known one.
                             log_to_file(f"Failed to get lullaby schedule: {e}")
-                            data["lullaby_volume"] = 50
 
                     except Exception as e:
                         import traceback

--- a/custom_components/cuboai/coordinator.py
+++ b/custom_components/cuboai/coordinator.py
@@ -183,7 +183,25 @@ def _fetch_local_data(
 
                         try:
                             stats = client.get_session_stats()
-                            data["connection_mode"] = stats.get("mode")
+                            mode = stats.get("mode")
+                            if mode:
+                                data["connection_mode"] = mode
+                            else:
+                                # The IOCTL answered but its body carried no parseable JSON,
+                                # so there is no mode in it. Leave the key UNSET so the merge
+                                # in _fetch_all carries the last known mode forward — exactly
+                                # what the except branch below already relies on.
+                                #
+                                # Writing None here instead dropped the Connection Mode sensor
+                                # to `unknown` for one poll and back again. Measured on a live
+                                # camera over 12h: 200 flaps, each lasting a median of 64.6s
+                                # (one poll interval), for a value that never actually changed
+                                # from "lan". "Unknown" is never true here anyway — this GET
+                                # only returns at all because the local session is up.
+                                log_to_file(
+                                    "[CuboAICoordinator] session stats carried no mode "
+                                    f"(raw_len={stats.get('raw_len')}); keeping the last known value"
+                                )
                         except Exception as e:
                             log_to_file(f"Failed to get session stats: {e}")
 

--- a/custom_components/cuboai/coordinator.py
+++ b/custom_components/cuboai/coordinator.py
@@ -272,18 +272,25 @@ def _fetch_local_data(
                         data["lullaby_song"] = ls.current_song_uuid
 
                         try:
+                            # get_lullaby_schedule() did not exist on CuboAIClient at all,
+                            # so this raised AttributeError on EVERY poll. The except below
+                            # swallowed it and the old hardcoded `= 50` fallback made the
+                            # result look like a real reading — the lullaby volume Home
+                            # Assistant showed was never once the camera's.
                             sched = client.get_lullaby_schedule()
-                            data["lullaby_volume"] = sched.volume
+                            vol = sched.get("volume")
+                            if vol is not None:
+                                data["lullaby_volume"] = vol
                             # The camera's ACTUAL sleep timer, echoed on this same
                             # response (offset 8): 0 = repeat forever, 1800 = 30 min,
                             # 3600 = 60 min. It was being read and thrown away, so the
                             # Lullaby Timer number had nothing to reconcile against and
                             # showed only whatever Home Assistant last set locally —
                             # "30 minutes" while the camera was actually on repeat.
-                            data["lullaby_timer_name"] = sched.timer_name
-                            data["lullaby_timer_minutes"] = (
-                                sched.timer_mode // 60 if sched.timer_mode else 0
-                            )
+                            timer_mode = sched.get("timer_mode")
+                            if timer_mode is not None:
+                                data["lullaby_timer_name"] = sched.get("timer")
+                                data["lullaby_timer_minutes"] = timer_mode // 60 if timer_mode else 0
                         except Exception as e:
                             # Do NOT invent a volume here. The previous fallback wrote a
                             # hardcoded 50, which the merge in _fetch_all then treated as

--- a/custom_components/cuboai/coordinator.py
+++ b/custom_components/cuboai/coordinator.py
@@ -100,7 +100,12 @@ def _fetch_local_data(
                     camera_ip=camera_ip if camera_ip else None,
                     defer_stream_start=False,
                     defer_video_start_late=False,
-                    auto_discover_lib=True,
+                    # auto_discover_lib=False: pure is the guaranteed backend everywhere in this
+                    # integration. An auto-discovered libIOTCAPIs_ALL (async_ensure_dependencies
+                    # downloads one into libs/<arch>/) would otherwise put SOME sessions on the
+                    # native backend while switch.py/light.py and the streamers stay pure. Only an
+                    # explicit lib_path/CUBOAI_LIB selects native.
+                    auto_discover_lib=False,
                 ) as sess:
                     client = CuboAIClient(sess)
 

--- a/custom_components/cuboai/coordinator.py
+++ b/custom_components/cuboai/coordinator.py
@@ -174,6 +174,11 @@ def _fetch_local_data(
                             ss_status = client.get_sleep_safety_status()
                             data["sleep_safety"] = ss_status.get("enabled")
                             data["baby_presence"] = ss_status.get("baby_presence_alert")
+                            # The camera distinguishes "Covered Face and Rollover" from
+                            # "Covered Face Only"; the sensor's On/Off hides that, and its
+                            # `raw_value` attribute read a key nothing ever wrote.
+                            data["sleep_safety_mode"] = ss_status.get("mode")
+                            data["sleep_safety_mode_desc"] = ss_status.get("mode_desc")
                         except Exception as e:
                             log_to_file(f"Failed to get sleep_safety: {e}")
 
@@ -275,7 +280,6 @@ def _fetch_local_data(
                             # Lullaby Timer number had nothing to reconcile against and
                             # showed only whatever Home Assistant last set locally —
                             # "30 minutes" while the camera was actually on repeat.
-                            data["lullaby_timer_mode"] = sched.timer_mode
                             data["lullaby_timer_name"] = sched.timer_name
                             data["lullaby_timer_minutes"] = (
                                 sched.timer_mode // 60 if sched.timer_mode else 0

--- a/custom_components/cuboai/go2rtc.py
+++ b/custom_components/cuboai/go2rtc.py
@@ -655,9 +655,14 @@ class Go2RTCManager:
         """Request playback of `start_epoch` (UTC) for `cam`; returns its URL.
 
         Writes the moment to the camera's state file, which the already-declared
-        DVR producer reads when a viewer connects. Any producer still running
-        for a previous request is stopped first, so the next viewer gets the
-        moment just asked for rather than the tail of the old one.
+        DVR producer reads when a viewer connects.
+
+        Note that nothing is stopped here. An earlier version of this docstring
+        claimed a previous producer was stopped first, but the body deliberately
+        does not do that — see the comment below on why go2rtc's DELETE is the
+        wrong tool. A producer left over from an earlier request keeps serving
+        that older moment until it ends; the next producer to start reads the
+        file written here.
         """
         import json
 

--- a/custom_components/cuboai/go2rtc.py
+++ b/custom_components/cuboai/go2rtc.py
@@ -489,19 +489,16 @@ class Go2RTCManager:
         if self._options.get("nvr_enabled") and self._options.get("nvr_password"):
             config["rtsp"]["username"] = self._options.get("nvr_username") or "cuboai"
             config["rtsp"]["password"] = self._options["nvr_password"]
-        if "streams" not in config:
-            config["streams"] = {}
-
-        # Overwrite our streams, keeping any other streams (e.g. from user).
-        # Drop stale cuboai_* entries first: this file is merged into, not
-        # replaced, so a stream we no longer generate (or one an older version
-        # wrote into the wrong key) would otherwise linger and be served.
-        for key in [k for k in config["streams"] if str(k).startswith("cuboai_")]:
-            if key not in self._streams:
-                _LOGGER.debug("Dropping stale go2rtc stream %s", key)
-                del config["streams"][key]
-        for k, v in self._streams.items():
-            config["streams"][k] = v
+        # This file is fully REGENERATED here, not merged into: `config` is built
+        # from scratch above and `_write` truncates. That is what makes a stale
+        # cuboai_* entry impossible — a stream we no longer generate simply is not
+        # written again. (An earlier comment here described a merge, and a loop
+        # tried to prune stale entries from `config["streams"]`; since that key was
+        # always empty at that point, the loop could never run. Removed rather than
+        # made real: the file lives inside the integration directory and is ours to
+        # own, and re-reading it would risk resurrecting exactly the stale entries
+        # the loop was meant to remove.)
+        config["streams"] = dict(self._streams)
         _LOGGER.info("go2rtc config written with streams: %s", sorted(self._streams))
 
         def _write():

--- a/custom_components/cuboai/media_player.py
+++ b/custom_components/cuboai/media_player.py
@@ -140,10 +140,35 @@ def _execute_lullaby_cmd(uid, account, password, camera_ip, cmd_type: str, song_
                 resp = client.stop_lullaby(song_uuid)
                 log_to_file(f"[Lullaby] Stop response: {resp}")
             elif cmd_type == "volume":
-                vol = int(volume) if volume is not None else 50
-                timer_val = LULLABY_TIMER_REPEAT
-                if timer and timer > 0:
-                    timer_val = timer * 60
+                # SET_LULLABY_VOL_DURATION is a COUPLED write: one struct carries both
+                # volume and the sleep timer, so whichever field the caller did not
+                # supply must be read from the camera rather than assumed. Defaulting
+                # the missing half to a constant meant changing the volume silently
+                # reset the sleep timer to repeat-forever, and changing the timer
+                # silently set the volume to 50.
+                cur_vol = cur_timer = None
+                try:
+                    sched = client.get_lullaby_schedule()
+                    cur_vol, cur_timer = sched.volume, sched.timer_mode
+                except Exception as e:
+                    log_to_file(f"[Lullaby] could not read current vol/timer before write: {e}")
+
+                if volume is not None:
+                    vol = int(volume)
+                elif cur_vol is not None:
+                    vol = int(cur_vol)
+                else:
+                    vol = 50
+                    log_to_file("[Lullaby] volume unknown and unreadable — falling back to 50")
+
+                if timer is not None:
+                    timer_val = timer * 60 if timer > 0 else LULLABY_TIMER_REPEAT
+                elif cur_timer is not None:
+                    timer_val = cur_timer          # preserve the camera's own timer
+                else:
+                    timer_val = LULLABY_TIMER_REPEAT
+                    log_to_file("[Lullaby] timer unknown and unreadable — falling back to repeat")
+
                 log_to_file(f"[Lullaby] Setting volume={vol} timer={timer_val}")
                 if hasattr(sess, "ioctl"):
                     resp = sess.ioctl(*build_set_lullaby_vol_duration(vol, timer_val))
@@ -755,7 +780,10 @@ class CuboLullabyPlayer(CoordinatorEntity, MediaPlayerEntity):
 
     async def _push_native_timer(self, minutes):
         cam = self.coordinator.data.get("cameras", {}).get(self._device_id, {}) if self.coordinator.data else {}
-        vol = cam.get("local", {}).get("lullaby_volume", 50)
+        # None means "keep whatever the camera has". SET_LULLABY_VOL_DURATION writes
+        # volume AND timer in one struct, so defaulting to 50 here silently reset the
+        # camera's volume as a side effect of changing the sleep timer.
+        vol = cam.get("local", {}).get("lullaby_volume")
         try:
             await self.hass.async_add_executor_job(
                 _execute_lullaby_cmd,

--- a/custom_components/cuboai/media_player.py
+++ b/custom_components/cuboai/media_player.py
@@ -99,7 +99,12 @@ def _execute_lullaby_cmd(uid, account, password, camera_ip, cmd_type: str, song_
             camera_ip=camera_ip if camera_ip else None,
             defer_stream_start=True,
             defer_video_start_late=True,
-            auto_discover_lib=True,
+            # auto_discover_lib=False: pure is the guaranteed backend everywhere in this
+            # integration. An auto-discovered libIOTCAPIs_ALL (async_ensure_dependencies
+            # downloads one into libs/<arch>/) would otherwise put SOME sessions on the
+            # native backend while switch.py/light.py and the streamers stay pure. Only an
+            # explicit lib_path/CUBOAI_LIB selects native.
+            auto_discover_lib=False,
         ) as sess:
             client = CuboAIClient(sess)
             if cmd_type == "play":

--- a/custom_components/cuboai/media_player.py
+++ b/custom_components/cuboai/media_player.py
@@ -112,7 +112,26 @@ def _execute_lullaby_cmd(uid, account, password, camera_ip, cmd_type: str, song_
                     song_uuid = list(LULLABY_CATALOG.keys())[0]
 
                 # IMPORTANT: Set vol/duration BEFORE playing, otherwise camera might ignore or immediately stop
-                vol = int(volume) if volume is not None else 50
+                #
+                # Both callers pass volume=None (the card path via select_source and
+                # async_media_play), and this used to fall back to a hardcoded 50 — so
+                # every lullaby play silently overrode whatever volume the user, or the
+                # CuboAi app, had set. SET_LULLABY_VOL_DURATION writes volume and timer
+                # together, so "not specified" has to mean "keep the camera's", not "50".
+                if volume is not None:
+                    vol = int(volume)
+                else:
+                    vol = None
+                    try:
+                        vol = int(client.get_lullaby_schedule().volume)
+                    except Exception as e:
+                        log_to_file(f"[Lullaby] could not read current volume before play: {e}")
+                    if vol is None:
+                        vol = 50
+                        log_to_file("[Lullaby] volume unknown and unreadable — falling back to 50")
+
+                # timer=None here means repeat-forever on purpose: the card path lets
+                # Home Assistant enforce the duration and stop playback itself.
                 timer_val = LULLABY_TIMER_REPEAT
                 if timer and timer > 0:
                     timer_val = timer * 60

--- a/custom_components/cuboai/media_player.py
+++ b/custom_components/cuboai/media_player.py
@@ -86,9 +86,9 @@ def _execute_lullaby_cmd(uid, account, password, camera_ip, cmd_type: str, song_
     try:
         from .tutk.cuboai_messages import (
             LULLABY_CATALOG,
-            LULLABY_TIMER_REPEAT,
             CuboAIClient,
-            build_set_lullaby_vol_duration,
+            build_get_lullaby_schedule,
+            build_set_lullaby_schedule,
         )
         from .tutk.cuboai_session import get_session
 
@@ -107,40 +107,46 @@ def _execute_lullaby_cmd(uid, account, password, camera_ip, cmd_type: str, song_
             auto_discover_lib=False,
         ) as sess:
             client = CuboAIClient(sess)
+
+            def _schedule_echo():
+                """Raw GET_LULLABY_SCHEDULE bytes, or None if it cannot be read.
+
+                SET_LULLABY_VOL_DURATION (2438) is the camera's ONLY write for the
+                lullaby volume and sleep timer, and its 140-byte struct carries BOTH
+                fields with no field mask — there is no volume-only or timer-only
+                opcode. So every write is necessarily a read-modify-write, and
+                `build_set_lullaby_schedule` takes this echo to preserve whichever
+                field the caller left as None.
+                """
+                try:
+                    _rt, raw = sess.ioctl(*build_get_lullaby_schedule())
+                    return raw
+                except Exception as e:
+                    log_to_file(f"[Lullaby] could not read the schedule echo: {e}")
+                    return None
+
             if cmd_type == "play":
                 if not song_uuid:
                     song_uuid = list(LULLABY_CATALOG.keys())[0]
 
                 # IMPORTANT: Set vol/duration BEFORE playing, otherwise camera might ignore or immediately stop
                 #
-                # Both callers pass volume=None (the card path via select_source and
-                # async_media_play), and this used to fall back to a hardcoded 50 — so
-                # every lullaby play silently overrode whatever volume the user, or the
-                # CuboAi app, had set. SET_LULLABY_VOL_DURATION writes volume and timer
-                # together, so "not specified" has to mean "keep the camera's", not "50".
-                if volume is not None:
-                    vol = int(volume)
-                else:
-                    vol = None
-                    try:
-                        vol = int(client.get_lullaby_schedule().volume)
-                    except Exception as e:
-                        log_to_file(f"[Lullaby] could not read current volume before play: {e}")
-                    if vol is None:
-                        vol = 50
-                        log_to_file("[Lullaby] volume unknown and unreadable — falling back to 50")
-
-                # timer=None here means repeat-forever on purpose: the card path lets
-                # Home Assistant enforce the duration and stop playback itself.
-                timer_val = LULLABY_TIMER_REPEAT
-                if timer and timer > 0:
-                    timer_val = timer * 60
-
-                log_to_file(f"[Lullaby] Setting vol={vol} timer={timer_val} BEFORE play")
+                # volume=None means "keep the camera's". Both callers pass None (the
+                # card path via select_source, and async_media_play), and this used to
+                # fall back to a hardcoded 50 — so every play silently overrode whatever
+                # volume the user or the CuboAi app had set.
+                #
+                # duration: minutes, 0 = repeat forever. The card path deliberately
+                # passes 0/None so the camera repeats and Home Assistant sends the stop.
+                duration = timer if (timer and timer > 0) else 0
+                op, payload = build_set_lullaby_schedule(
+                    volume=volume, duration=duration, get_resp_bytes=_schedule_echo()
+                )
+                log_to_file(f"[Lullaby] Setting vol/duration BEFORE play (vol={volume} dur={duration})")
                 if hasattr(sess, "ioctl"):
-                    sess.ioctl(*build_set_lullaby_vol_duration(vol, timer_val))
+                    sess.ioctl(op, payload)
                 else:
-                    sess._cubo_set(build_set_lullaby_vol_duration(vol, timer_val)[1])
+                    sess._cubo_set(payload)
 
                 log_to_file(f"[Lullaby] Playing song: {song_uuid}")
                 resp = client.play_lullaby(song_uuid)
@@ -159,40 +165,20 @@ def _execute_lullaby_cmd(uid, account, password, camera_ip, cmd_type: str, song_
                 resp = client.stop_lullaby(song_uuid)
                 log_to_file(f"[Lullaby] Stop response: {resp}")
             elif cmd_type == "volume":
-                # SET_LULLABY_VOL_DURATION is a COUPLED write: one struct carries both
-                # volume and the sleep timer, so whichever field the caller did not
-                # supply must be read from the camera rather than assumed. Defaulting
-                # the missing half to a constant meant changing the volume silently
-                # reset the sleep timer to repeat-forever, and changing the timer
-                # silently set the volume to 50.
-                cur_vol = cur_timer = None
-                try:
-                    sched = client.get_lullaby_schedule()
-                    cur_vol, cur_timer = sched.volume, sched.timer_mode
-                except Exception as e:
-                    log_to_file(f"[Lullaby] could not read current vol/timer before write: {e}")
-
-                if volume is not None:
-                    vol = int(volume)
-                elif cur_vol is not None:
-                    vol = int(cur_vol)
-                else:
-                    vol = 50
-                    log_to_file("[Lullaby] volume unknown and unreadable — falling back to 50")
-
-                if timer is not None:
-                    timer_val = timer * 60 if timer > 0 else LULLABY_TIMER_REPEAT
-                elif cur_timer is not None:
-                    timer_val = cur_timer          # preserve the camera's own timer
-                else:
-                    timer_val = LULLABY_TIMER_REPEAT
-                    log_to_file("[Lullaby] timer unknown and unreadable — falling back to repeat")
-
-                log_to_file(f"[Lullaby] Setting volume={vol} timer={timer_val}")
+                # Coupled write again: pass only what is being changed and let the
+                # builder carry the other field over from the camera's own echo.
+                # Previously the unsupplied half was invented, so changing the volume
+                # reset the sleep timer to repeat-forever and changing the timer reset
+                # the volume to 50.
+                duration = None if timer is None else (timer if timer > 0 else 0)
+                op, payload = build_set_lullaby_schedule(
+                    volume=volume, duration=duration, get_resp_bytes=_schedule_echo()
+                )
+                log_to_file(f"[Lullaby] Setting volume={volume} duration={duration}")
                 if hasattr(sess, "ioctl"):
-                    resp = sess.ioctl(*build_set_lullaby_vol_duration(vol, timer_val))
+                    resp = sess.ioctl(op, payload)
                 else:
-                    resp = sess._cubo_set(build_set_lullaby_vol_duration(vol, timer_val)[1])
+                    resp = sess._cubo_set(payload)
     except Exception as e:
         log_to_file(f"[Lullaby] ERROR: {e}")
         # Propagate so the retry decorator can retry and then surface a clean

--- a/custom_components/cuboai/number.py
+++ b/custom_components/cuboai/number.py
@@ -211,11 +211,16 @@ class CuboNightLightBrightnessNumber(CoordinatorEntity, NumberEntity):
 
     @property
     def native_value(self):
+        """The camera's night-light brightness, or unknown.
+
+        This used to return a hardcoded 100 when the value was missing — and it
+        was ALWAYS missing, because nothing populated `local["brightness"]`. So
+        the entity read 100 no matter what the camera was set to. Reporting
+        unknown is the honest answer when the poll has not produced a value.
+        """
         cam = self.coordinator.data.get("cameras", {}).get(self._device_id, {})
         bright_pct = cam.get("local", {}).get("brightness")
-        if bright_pct is not None:
-            return int(bright_pct)
-        return 100
+        return int(bright_pct) if bright_pct is not None else None
 
     @property
     def device_info(self):

--- a/custom_components/cuboai/number.py
+++ b/custom_components/cuboai/number.py
@@ -49,7 +49,12 @@ class CuboLullabyTimerNumber(CoordinatorEntity, RestoreNumber):
         self._attr_native_step = 30
         self._attr_native_unit_of_measurement = "min"
 
+        # Restored across reloads; used only until the camera tells us its own value.
         self._timer_value = 30
+        #: A value the user picked that has not yet been pushed to the camera. It
+        #: wins over the camera's reading so a selection made before pressing play
+        #: is not overwritten by the next poll; it clears once the camera agrees.
+        self._pending = None
 
     async def async_added_to_hass(self) -> None:
         """Restore the last timer value after a reload or HA restart.
@@ -66,8 +71,51 @@ class CuboLullabyTimerNumber(CoordinatorEntity, RestoreNumber):
             _LOGGER.debug("Could not restore lullaby timer value", exc_info=True)
 
     @property
+    def _camera_minutes(self):
+        """The sleep timer the CAMERA reports, in minutes, or None if unknown.
+
+        From GET_LULLABY_SCHEDULE (timer_mode @8): 0 = repeat forever,
+        1800 = 30 min, 3600 = 60 min.
+        """
+        data = self.coordinator.data or {}
+        cam = data.get("cameras", {}).get(self._device_id, {})
+        return cam.get("local", {}).get("lullaby_timer_minutes")
+
+    @property
     def native_value(self):
+        """What the camera is actually set to, unless a newer local pick is pending.
+
+        This used to return a purely local value that started at a hardcoded 30 and
+        was never reconciled with the camera — so a lullaby the camera was repeating
+        indefinitely still showed "30 min" in Home Assistant. The camera reports its
+        real timer on a response the coordinator already reads.
+        """
+        cam_minutes = self._camera_minutes
+        if self._pending is not None:
+            if cam_minutes is not None and int(cam_minutes) == int(self._pending):
+                self._pending = None      # the camera caught up
+            else:
+                return self._pending
+        if cam_minutes is not None:
+            return int(cam_minutes)
         return self._timer_value
+
+    @property
+    def extra_state_attributes(self):
+        cam_minutes = self._camera_minutes
+        data = self.coordinator.data or {}
+        cam = data.get("cameras", {}).get(self._device_id, {})
+        return {
+            "camera_timer_minutes": cam_minutes,
+            "camera_timer_mode": cam.get("local", {}).get("lullaby_timer_name"),
+            "pending_change": self._pending,
+            # True while Home Assistant is showing a value the camera has not adopted.
+            "differs_from_camera": (
+                self._pending is not None
+                and cam_minutes is not None
+                and int(cam_minutes) != int(self._pending)
+            ),
+        }
 
     @property
     def device_info(self):
@@ -80,6 +128,9 @@ class CuboLullabyTimerNumber(CoordinatorEntity, RestoreNumber):
 
     async def async_set_native_value(self, value: float) -> None:
         self._timer_value = int(value)
+        # Held as pending until the camera reports this value back, so the pick
+        # survives the next poll instead of snapping to the camera's old setting.
+        self._pending = int(value)
         self.async_write_ha_state()
 
         # Notify the lullaby player: if a NATIVE lullaby is playing it pushes

--- a/custom_components/cuboai/number.py
+++ b/custom_components/cuboai/number.py
@@ -192,7 +192,12 @@ class CuboNightLightBrightnessNumber(CoordinatorEntity, NumberEntity):
                 camera_ip=self._camera_ip if self._camera_ip else None,
                 defer_stream_start=False,
                 defer_video_start_late=False,
-                auto_discover_lib=True,
+                # auto_discover_lib=False: pure is the guaranteed backend everywhere in this
+                # integration. An auto-discovered libIOTCAPIs_ALL (async_ensure_dependencies
+                # downloads one into libs/<arch>/) would otherwise put SOME sessions on the
+                # native backend while switch.py/light.py and the streamers stay pure. Only an
+                # explicit lib_path/CUBOAI_LIB selects native.
+                auto_discover_lib=False,
             ) as sess:
                 client = CuboAIClient(sess)
                 client.set_brightness(bright_pct)

--- a/custom_components/cuboai/select.py
+++ b/custom_components/cuboai/select.py
@@ -45,7 +45,12 @@ def _set_night_vision(uid, account, password, camera_ip, mode: int):
             camera_ip=camera_ip if camera_ip else None,
             defer_stream_start=False,
             defer_video_start_late=False,
-            auto_discover_lib=True,
+            # auto_discover_lib=False: pure is the guaranteed backend everywhere in this
+            # integration. An auto-discovered libIOTCAPIs_ALL (async_ensure_dependencies
+            # downloads one into libs/<arch>/) would otherwise put SOME sessions on the
+            # native backend while switch.py/light.py and the streamers stay pure. Only an
+            # explicit lib_path/CUBOAI_LIB selects native.
+            auto_discover_lib=False,
         ) as sess:
             if hasattr(sess, "ioctl"):
                 resp_type, raw = sess.ioctl(*build_get_hw_control())

--- a/custom_components/cuboai/sensor.py
+++ b/custom_components/cuboai/sensor.py
@@ -466,7 +466,11 @@ class CuboSleepSafetySensor(CoordinatorEntity, SensorEntity):
     @property
     def extra_state_attributes(self):
         cam = self.coordinator.data.get("cameras", {}).get(self._device_id, {})
-        return {"raw_value": cam.get("local", {}).get("sleep_safety_raw")}
+        local = cam.get("local", {})
+        return {
+            "mode": local.get("sleep_safety_mode"),
+            "mode_description": local.get("sleep_safety_mode_desc"),
+        }
 
     @property
     def device_info(self):

--- a/custom_components/cuboai/switch.py
+++ b/custom_components/cuboai/switch.py
@@ -228,7 +228,11 @@ class CuboStatusLEDSwitch(CoordinatorEntity, SwitchEntity):
     @property
     def is_on(self):
         cam = self.coordinator.data.get("cameras", {}).get(self._device_id, {})
-        return cam.get("local", {}).get("status_led_on", False)
+        # `status_light_on` is the key the coordinator poll writes, from
+        # get_hw_control().status_light_on_off. This entity read `status_led_on`,
+        # which the poll never writes — so the switch showed only its own
+        # optimistic write and returned to False on every restart.
+        return cam.get("local", {}).get("status_light_on", False)
 
     @property
     def device_info(self):
@@ -244,7 +248,7 @@ class CuboStatusLEDSwitch(CoordinatorEntity, SwitchEntity):
             _set_status_led, self._uid, self._account, self._password, self._camera_ip, True
         )
         cam = self.coordinator.data.setdefault("cameras", {}).setdefault(self._device_id, {})
-        cam.setdefault("local", {})["status_led_on"] = True
+        cam.setdefault("local", {})["status_light_on"] = True
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
@@ -252,7 +256,7 @@ class CuboStatusLEDSwitch(CoordinatorEntity, SwitchEntity):
             _set_status_led, self._uid, self._account, self._password, self._camera_ip, False
         )
         cam = self.coordinator.data.setdefault("cameras", {}).setdefault(self._device_id, {})
-        cam.setdefault("local", {})["status_led_on"] = False
+        cam.setdefault("local", {})["status_light_on"] = False
         self.async_write_ha_state()
 
 

--- a/custom_components/cuboai/switch.py
+++ b/custom_components/cuboai/switch.py
@@ -108,6 +108,30 @@ class CuboSleepModeSwitch(CoordinatorEntity, SwitchEntity):
         self.async_write_ha_state()
 
 
+def _apply_verified(entity, key, requested, actual, label):
+    """Write the camera's ACTUAL post-set value into the coordinator cache.
+
+    When the two disagree the camera accepted the command and ignored it, which
+    is a real (and on this firmware, expected) outcome — say so once, clearly,
+    instead of showing a state the camera is not in.
+    """
+    if bool(actual) != bool(requested):
+        if not getattr(entity, "_ignored_warned", False):
+            entity._ignored_warned = True
+            _LOGGER.warning(
+                "%s: the camera accepted turning %s %s but still reports %s. This firmware "
+                "acknowledges the command and does not apply it, so Home Assistant is showing "
+                "the camera's real state rather than the requested one.",
+                entity.entity_id or entity._attr_name,
+                label,
+                "on" if requested else "off",
+                "on" if actual else "off",
+            )
+    cam = entity.coordinator.data.setdefault("cameras", {}).setdefault(entity._device_id, {})
+    cam.setdefault("local", {})[key] = bool(actual)
+    entity.async_write_ha_state()
+
+
 @retry_camera_command("Status LED command")
 def _set_status_led(uid, account, password, camera_ip, on: bool):
     """Synchronous function to set status led."""
@@ -307,9 +331,25 @@ class CuboFlipScreenSwitch(CoordinatorEntity, SwitchEntity):
 
 @retry_camera_command("Baby presence command")
 def _set_baby_presence(uid, account, password, camera_ip, on: bool):
-    """Synchronous function to set baby presence alert."""
+    """Set the baby-presence alert and return the state the camera actually reports.
+
+    `baby_presence_alert` is one of four coupled fields in SET_SLEEP_SAFETY_SETTING.
+    A live round-trip against this firmware showed the SET is accepted (result=0)
+    while the read-back is UNCHANGED in both directions — and that this is not a
+    transport problem, since `safety_alert`, `cover_alert` and `sensitivity` read
+    back exactly as written in the same call. The field is accepted and ignored,
+    the same way the status LED is.
+
+    This is a baby monitor, so a presence alert that Home Assistant shows as
+    enabled while the camera has not enabled it is the wrong failure to be quiet
+    about. Read the value back and return what the camera really reports.
+    """
     try:
-        from .tutk.cuboai_messages import build_get_sleep_safety_setting, build_set_sleep_safety_setting
+        from .tutk.cuboai_messages import (
+            CuboAIClient,
+            build_get_sleep_safety_setting,
+            build_set_sleep_safety_setting,
+        )
         from .tutk.cuboai_session import get_session
 
         with get_session(
@@ -327,6 +367,11 @@ def _set_baby_presence(uid, account, password, camera_ip, on: bool):
             else:
                 resp_type, raw = sess._send_ioc(*build_get_sleep_safety_setting())
                 sess._send_ioc(*build_set_sleep_safety_setting(raw, baby_presence_alert=on))
+            try:
+                return bool(CuboAIClient(sess).get_sleep_safety_status().get("baby_presence_alert"))
+            except Exception as e:
+                _LOGGER.debug("Baby-presence read-back failed, assuming requested state: %s", e)
+                return on
     except Exception as e:
         _LOGGER.error(f"Failed to set baby presence: {e}")
         raise
@@ -362,17 +407,13 @@ class CuboBabyPresenceSwitch(CoordinatorEntity, SwitchEntity):
         }
 
     async def async_turn_on(self, **kwargs):
-        await self.hass.async_add_executor_job(
+        actual = await self.hass.async_add_executor_job(
             _set_baby_presence, self._uid, self._account, self._password, self._camera_ip, True
         )
-        cam = self.coordinator.data.setdefault("cameras", {}).setdefault(self._device_id, {})
-        cam.setdefault("local", {})["baby_presence"] = True
-        self.async_write_ha_state()
+        _apply_verified(self, "baby_presence", True, actual, "the baby-presence alert")
 
     async def async_turn_off(self, **kwargs):
-        await self.hass.async_add_executor_job(
+        actual = await self.hass.async_add_executor_job(
             _set_baby_presence, self._uid, self._account, self._password, self._camera_ip, False
         )
-        cam = self.coordinator.data.setdefault("cameras", {}).setdefault(self._device_id, {})
-        cam.setdefault("local", {})["baby_presence"] = False
-        self.async_write_ha_state()
+        _apply_verified(self, "baby_presence", False, actual, "the baby-presence alert")

--- a/custom_components/cuboai/tutk/cuboai_messages.py
+++ b/custom_components/cuboai/tutk/cuboai_messages.py
@@ -1707,19 +1707,65 @@ def parse_feature_support(raw: bytes) -> dict:
     return d
 
 
+def _json_span(raw: bytes):
+    """Byte span of the FIRST complete {...} object in `raw`, or None.
+
+    Brace-counted, and string-aware so a brace inside a JSON string value does not
+    close the object. This exists because the response is a binary IOCTL blob with
+    the JSON embedded in it: the trailing bytes are counters and padding, and any
+    stray 0x7D ('}') among them made a greedy first-{ to last-} match span past the
+    end of the real object, so json.loads failed and the whole response was
+    discarded. Whether that happened depended on the counter values, which is why
+    it presented as an intermittent, self-healing parse failure rather than a
+    consistent one.
+    """
+    start = raw.find(b'{')
+    if start < 0:
+        return None
+    depth, in_str, esc = 0, False, False
+    for i in range(start, len(raw)):
+        ch = raw[i]
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == 0x5C:        # backslash
+                esc = True
+            elif ch == 0x22:        # closing quote
+                in_str = False
+            continue
+        if ch == 0x22:
+            in_str = True
+        elif ch == 0x7B:            # {
+            depth += 1
+        elif ch == 0x7D:            # }
+            depth -= 1
+            if depth == 0:
+                return start, i + 1
+    return None                     # truncated: no matching close brace
+
+
 def _extract_json(raw: bytes):
     """Pull the first {...} object out of a response blob, repairing the camera's bare
     (unquoted) dotted-quad IP values so json.loads accepts it. Returns dict or None."""
     import re, json
+
+    def _load(chunk: bytes):
+        txt = chunk.decode('latin1', 'replace')
+        txt = re.sub(r':\s*(\d{1,3}(?:\.\d{1,3}){3})\s*([,}\]])', r': "\1"\2', txt)  # quote bare IPs
+        try:
+            return json.loads(txt)
+        except Exception:
+            return None
+
+    span = _json_span(raw)
+    if span:
+        obj = _load(raw[span[0]:span[1]])
+        if obj is not None:
+            return obj
+    # Fall back to the historical greedy match so this can only ever parse MORE
+    # responses than before, never fewer.
     m = re.search(rb'\{.*\}', raw, re.S)
-    if not m:
-        return None
-    txt = m.group(0).decode('latin1', 'replace')
-    txt = re.sub(r':\s*(\d{1,3}(?:\.\d{1,3}){3})\s*([,}\]])', r': "\1"\2', txt)  # quote bare IPs
-    try:
-        return json.loads(txt)
-    except Exception:
-        return None
+    return _load(m.group(0)) if m else None
 
 def parse_session_stats(raw: bytes) -> dict:
     """GET_SESSION_STATS_RESP (0x0935) — UNDOCUMENTED. The camera's own per-session

--- a/custom_components/cuboai/tutk/cuboai_messages.py
+++ b/custom_components/cuboai/tutk/cuboai_messages.py
@@ -337,6 +337,23 @@ class CuboAIClient:
             raise ValueError(f"Unexpected response type {resp_type}")
         return LullabyVolDuration.parse(data)
 
+    def get_lullaby_schedule(self) -> dict:
+        """GET_LULLABY_SCHEDULE (2440) — the camera's lullaby volume + sleep-timer echo.
+
+        This is the ONLY readable source for the lullaby volume and timer:
+        GET_LULLABY_VOL_DURATION (2436) carries the current song and play state but
+        NOT the volume (see parse_lullaby's `'volume': None` note), and the write
+        (SET_LULLABY_VOL_DURATION, 2438) is a coupled struct that needs this echo to
+        preserve whichever field a caller leaves alone.
+
+        Returns parse_lullaby_schedule's dict: `volume`, `timer_mode` (seconds:
+        0 = repeat, 1800 = 30 min, 3600 = 60 min) and `timer` (its label).
+        """
+        resp_type, data = self.transport.ioctl(*build_get_lullaby_schedule())
+        if resp_type != IOTYPE_USER_GET_LULLABY_SCHEDULE_RESP:
+            raise ValueError(f"Unexpected response type {resp_type}")
+        return parse_lullaby_schedule(data)
+
     def get_cry_detect_status(self) -> dict:
         resp_type, data = self.transport.ioctl(*build_get_cry_detect())
         return parse_cry_detection(data)

--- a/custom_components/cuboai/tutk/cuboai_pure.py
+++ b/custom_components/cuboai/tutk/cuboai_pure.py
@@ -248,29 +248,55 @@ def _block_transform(blk: bytes) -> bytes:
                        _ror32(r10, 11), _ror32(r9, 15))
 
 
-def transcode(plain: bytes) -> bytes:
-    """Full TUTK TransCodePartial: 16-byte block transform + tail XOR.
+def transcode(plain: bytes, swap_tail: bool = True) -> bytes:
+    """Full TUTK TransCodePartial: 16-byte block transform + tail XOR-and-Swap.
 
     This maps the real plaintext av-connect to the exact bytes that go on the
     wire. The account, password, header and every structured field live in full
     16-byte blocks, so they are transcoded by the block transform.
 
-    The trailing `len & 0xF` bytes are a plain XOR: `K16[i] ^ plain[i]`. TUTK has
-    a `Swap` byte-permutation applied to the tail for tail lengths 2/4/8, but the
-    IOTC SendMessage path used for these LAN frames does NOT apply it — every
-    frame type matches plain XOR (the 88-byte probe/ACK with trailer
-    `63041313040c0c63`, the 76-byte IOCTL request, the 598-byte av-connect, and
-    the IOCTL responses). Do NOT re-add Swap here — it corrupts the probe tail
-    and breaks connect.
+    The trailing `len & 0xF` bytes are `Swap(plain_tail XOR K16)` (see
+    `_tail_swap`). `swap_tail=False` reproduces the NO-Swap wire of the
+    pre-session SEARCH/broadcast frames (build_probe/build_ack/build_lan_query),
+    which are the only frames that skip it.
+
+    (An earlier revision of this file documented the tail as a plain XOR
+    *everywhere* and warned "do NOT re-add Swap — it breaks connect". That was
+    wrong for the DATA channel and is what mangled any frame whose tail length
+    is 2/4/8 — e.g. the 216-byte lullaby-schedule SET, tail 8. The nuance is:
+    Swap on the data channel, no Swap on the search/direct frames.)
     """
     n = len(plain)
     full = n - (n & 0xF)
     out = bytearray(n)
     for off in range(0, full, 16):
         out[off:off + 16] = _block_transform(plain[off:off + 16])
-    for i in range(full, n):
-        out[i] = _K16[i - full] ^ plain[i]
+    tl = n - full
+    if tl:
+        xored = bytes(_K16[i] ^ plain[full + i] for i in range(tl))
+        out[full:] = _tail_swap(xored, tl) if swap_tail else xored
     return bytes(out)
+
+
+# TUTK TransCodePartial / ReverseTransCodePartial apply a `Swap` byte-permutation
+# (lib 0x2714f0) to the partial-block TAIL, but ONLY for tail lengths 2/4/8 (identity
+# for every other length). Reversed from the .so and confirmed byte-for-byte against
+# the real lib via ctypes for ALL lengths: encode `wire_tail = Swap(plain_tail XOR K)`;
+# decode `plain_tail = Swap(wire_tail) XOR K` (Swap is an involution). This is why a
+# 148-byte schedule SET (216-byte frame, tail 8) whose duration lived in the tail read
+# back mangled when the tail was a plain XOR; tails 6/12 (av-connect, IOCTL GET) are
+# identity, so they were always correct.
+_TAIL_SWAP = {2: (1, 0), 4: (2, 3, 0, 1), 8: (7, 4, 3, 2, 1, 6, 5, 0)}
+
+
+def _tail_swap(buf, length):
+    """Apply the TransCodePartial tail `Swap` permutation (identity unless length is
+    2/4/8; an involution). Used by BOTH `transcode` and `inv_transcode` so the wire
+    encode/decode match native TransCodePartial / ReverseTransCodePartial exactly."""
+    perm = _TAIL_SWAP.get(length)
+    if perm is None:
+        return buf
+    return bytes(buf[j] for j in perm)
 
 
 def _rol32(v, r):
@@ -304,14 +330,19 @@ def _inv_block_transform(blk: bytes) -> bytes:
 
 
 def inv_transcode(wire: bytes) -> bytes:
-    """Full inverse of `transcode` (what the camera computes on receive)."""
+    """Full inverse of `transcode` — byte-identical to the native library's
+    `ReverseTransCodePartial` (lib 0x2720d0). The tail (len & 0xF == 2/4/8) is
+    un-Swapped then XOR'd: `plain_tail = Swap(wire_tail) XOR K16` (Swap is an
+    involution, so the same `_tail_swap` inverts the encode)."""
     n = len(wire)
     full = n - (n & 0xF)
     out = bytearray(n)
     for off in range(0, full, 16):
         out[off:off + 16] = _inv_block_transform(wire[off:off + 16])
-    for i in range(full, n):
-        out[i] = _K16[i - full] ^ wire[i]
+    tl = n - full
+    if tl:
+        swapped = _tail_swap(wire[full:], tl)      # involution: undo the encode-side Swap
+        out[full:] = bytes(_K16[i] ^ swapped[i] for i in range(tl))
     return bytes(out)
 
 
@@ -791,12 +822,12 @@ def _build_ls_plaintext(uid, R: int, ack: bool) -> bytes:
 
 def build_probe(uid: bytes, R: int) -> bytes:
     """88-byte LAN-search probe wire packet (transcode of the true plaintext)."""
-    return transcode(_build_ls_plaintext(uid, R, ack=False))
+    return transcode(_build_ls_plaintext(uid, R, ack=False), swap_tail=False)  # search: no Swap
 
 
 def build_ack(uid: bytes, R: int) -> bytes:
     """88-byte LAN-search ACK wire packet (probe with plaintext[64]=0x02)."""
-    return transcode(_build_ls_plaintext(uid, R, ack=True))
+    return transcode(_build_ls_plaintext(uid, R, ack=True), swap_tail=False)   # search: no Swap
 
 
 # ── IOTC LAN device-identity query (message type 0x0402) ──────────────────────
@@ -823,7 +854,7 @@ def build_lan_query(uid, R: int, mid: bytes = None) -> bytes:
     t[36:38] = struct.pack("<H", R & 0xFFFF)
     t[38:44] = mid if mid is not None else _CLIENT_FINGERPRINT
     t[44:52] = _LQ_TAIL8
-    return transcode(bytes(t))
+    return transcode(bytes(t), swap_tail=False)  # search/broadcast frame: no Swap on the tail
 
 
 def build_close(R: int, session_fp: bytes = None) -> bytes:

--- a/custom_components/cuboai/tutk/cuboai_pure.py
+++ b/custom_components/cuboai/tutk/cuboai_pure.py
@@ -1825,6 +1825,16 @@ class TUTKDirectSession:
         # (_unwrap_index == raw idx while no wrap has occurred).
         # REGRESSION SWITCH, NOT A TUNABLE: `=0` reopens the freeze-at-wrap — keep ON.
         self._dataack_wrap = os.environ.get("CUBOAI_DATAACK_WRAP", "1") != "0"
+        # SECOND-STREAM dead-read fix (default ON): `done_upto` is a per-reader local that starts
+        # at -1, but the camera's AV message-index is SESSION-scoped. So the FIRST read of a
+        # session works and every read after it meets an index already far past the +256 accept
+        # window — EVERY fragment is rejected, forever, and the reader emits zero access units
+        # while fragments keep arriving at full rate. Silent: no error, no gap counter moving.
+        # Reachable through the legacy shim (cuboai_transport_py.start_video() opens a fresh
+        # av_frames() iterator each call). Anchoring the window at the first accepted AU start
+        # fixes it; the seed only fires when the index is out of window, so a normal
+        # fresh-session stream is byte-identical.
+        self._idx_seed = os.environ.get("CUBOAI_IDX_SEED", "1") != "0"
         # minimum in-order wait (AU-indices) before advancing past an absent AU — the
         # scaled grace (~4 at LAN) is too short to wait out a >grace-late frag-burst, so
         # the late-but-complete AU is still skipped+rejected; this floor holds each AU long
@@ -3331,9 +3341,10 @@ class TUTKDirectSession:
                             gi.result = bytes(dec[68:min(len(dec), 68 + max(0, avlen - 4))])
                             gi.done.set()
                         continue
-                    idx = struct.unpack("<H", dec[56:58])[0]
+                    raw_idx = struct.unpack("<H", dec[56:58])[0]
+                    idx = raw_idx
                     if self._idx_modular:                 # H1: lift the u16 index into done_upto's
-                        idx = _unwrap_index(idx, done_upto)  # space so the gate survives the wrap
+                        idx = _unwrap_index(raw_idx, done_upto)  # space so the gate survives the wrap
                     frag = struct.unpack("<H", dec[46:48])[0]
                     avlen = struct.unpack("<H", dec[52:54])[0]
                     chunk = bytes(dec[64:64 + max(0, avlen)])
@@ -3357,6 +3368,16 @@ class TUTKDirectSession:
                         if not is_marker(chunk):
                             continue
                         gmax = frag
+                        # SECOND-STREAM dead-read fix (see _idx_seed): this is THIS reader's first
+                        # accepted access-unit start. done_upto still holds its -1 initialiser, but
+                        # the camera's message-index is session-scoped, so on any read after the
+                        # first it is already past the +256 accept window and EVERY fragment would
+                        # be rejected from here on. Anchor the window here instead. Fires only when
+                        # the index is out of window (never on a fresh-session stream), so the
+                        # normal path is byte-identical.
+                        if self._idx_seed and not (done_upto < idx <= done_upto + 256):
+                            done_upto = raw_idx - 1
+                            idx = _unwrap_index(raw_idx, done_upto) if self._idx_modular else raw_idx
                     else:
                         fwd = (frag - gmax) & 0xFFFF
                         back = (gmax - frag) & 0xFFFF

--- a/custom_components/cuboai/tutk/cuboai_pure.py
+++ b/custom_components/cuboai/tutk/cuboai_pure.py
@@ -908,6 +908,16 @@ def _unwrap_index(idx_u16, done_upto):
     return done_upto + ((idx_u16 - done_upto) & 0xFFFF)
 
 
+def _unwrap_index_back(idx_u16, cur):
+    """Lift a u16 wire counter BACKWARD into `cur`'s unbounded monotonic space: the nearest value
+    at-or-below `cur` congruent to idx_u16 (mod 65536). The mirror of `_unwrap_index`, for wire
+    values that always refer to something ALREADY SENT (a resend request naming one of our own
+    recent frames). While `cur` < 65536 this is the identity, so the wire is unchanged below the
+    wrap; past it the lookup keeps resolving instead of silently missing.
+    """
+    return cur - ((cur - idx_u16) & 0xFFFF)
+
+
 def is_keepalive_probe(raw: bytes) -> bool:
     """True iff `raw` is the camera's 24-byte IOTC keepalive (alive-check) probe.
 
@@ -3889,6 +3899,8 @@ class TUTKDirectSession:
                                              # underruns (measured 72ms vs the 64ms it plays at) -> breakage
         period = 1024.0 / rate               # AAC frame duration (== 64 ms at 16 kHz): feed at EXACTLY this
         finished = False
+        # REGRESSION SWITCH, NOT A TUNABLE: OFF (=0) reopens the talkback resend-lookup wrap death.
+        _talk_wrap = os.environ.get("CUBOAI_TALK_WRAP", "1") != "0"   # see the SACK-replay lookup below
         sent_buf = {}                        # talk_frag -> au, for resend on the camera's 0x09 SACK
         t0 = time.time()
         self._talk_stop = False              # cooperative stop flag (set by stop_audio())
@@ -3966,6 +3978,20 @@ class TUTKDirectSession:
                             if 0 < cnt < 256 and C != 0xFFFF:
                                 for k in range(min(cnt, (len(dec) - 50) // 2)):
                                     frag = (C + struct.unpack_from('<H', dec, 50 + 2 * k)[0]) & 0xFFFF
+                                    if _talk_wrap:
+                                        # talk_frag is MONOTONIC (it must never restart when a
+                                        # looped file wraps its content), so sent_buf's keys are
+                                        # unbounded — but the SACK entry decodes to a u16. Past
+                                        # 65536 frames (64 ms/frame => ~70 min of continuous or
+                                        # looping talkback) every sent_buf.get(u16) MISSES and
+                                        # talkback loss-recovery SILENTLY STOPS (resends_sent just
+                                        # stops rising; the wire stays well-formed, so nothing
+                                        # looks wrong). Lift the u16 BACKWARD into talk_frag's
+                                        # space — resends are always for already-sent frames, so
+                                        # the nearest match at-or-below the current frag is the
+                                        # right one. Below the wrap this is the identity, so the
+                                        # wire is unchanged.
+                                        frag = _unwrap_index_back(frag, talk_frag)
                                     au = sent_buf.get(frag)
                                     if au is not None:
                                         s.sendto(build_talk_audio(R, channel, self._seq, talk_relseq, frag, frag, au), cam)

--- a/custom_components/cuboai/tutk/cuboai_pure.py
+++ b/custom_components/cuboai/tutk/cuboai_pure.py
@@ -1805,6 +1805,16 @@ class TUTKDirectSession:
         # accept-window survives the wrap. Byte-identical pre-wrap; OFF reverts to the historical
         # non-modular gate, which dead-stalls a continuous stream ~every 46 min at the wrap.
         self._idx_modular = os.environ.get("CUBOAI_IDX_MODULAR", "1") != "0"
+        # Same wrap class as _idx_modular, on the OTHER u16 counter (default ON): the camera's
+        # IO message-index [56:58] wraps at 65536 while `_data_ack` is an unbounded monotonic
+        # int, so past the wrap `(self._data_ack + 1) in self._cam_msgs` can never be true again
+        # and _data_ack FREEZES — the D field of every subsequent host->cam ACK stops advancing
+        # ([40:42] must wrap 0xFFFF->0x0000) and the camera's send-window stops being credited.
+        # Lifting the idx into _data_ack's space (_unwrap_index) and discarding consumed entries
+        # keeps the contiguous edge advancing across the wrap. Byte-identical pre-wrap
+        # (_unwrap_index == raw idx while no wrap has occurred).
+        # REGRESSION SWITCH, NOT A TUNABLE: `=0` reopens the freeze-at-wrap — keep ON.
+        self._dataack_wrap = os.environ.get("CUBOAI_DATAACK_WRAP", "1") != "0"
         # minimum in-order wait (AU-indices) before advancing past an absent AU — the
         # scaled grace (~4 at LAN) is too short to wait out a >grace-late frag-burst, so
         # the late-but-complete AU is still skipped+rejected; this floor holds each AU long
@@ -2218,11 +2228,22 @@ class TUTKDirectSession:
             return
         if self._is_io_frame(dec):
             idx = struct.unpack("<H", dec[56:58])[0]
-            self._cam_msgs.add(idx)
             if idx == 0:
                 self._got_first = True
-            while (self._data_ack + 1) in self._cam_msgs:
-                self._data_ack += 1
+            if self._dataack_wrap:
+                # wrap-safe: store the idx lifted into _data_ack's unbounded space, advance the
+                # contiguous edge, and drop consumed entries (bounds the set + prevents a stale
+                # wrapped value from false-advancing a later epoch). Pre-wrap this is identical to
+                # the else-branch (_unwrap_index == raw idx, and _data_ack depends only on
+                # contiguity, which the discard does not change).
+                self._cam_msgs.add(_unwrap_index(idx, self._data_ack))
+                while (self._data_ack + 1) in self._cam_msgs:
+                    self._data_ack += 1
+                    self._cam_msgs.discard(self._data_ack)
+            else:
+                self._cam_msgs.add(idx)
+                while (self._data_ack + 1) in self._cam_msgs:
+                    self._data_ack += 1
             return
         # AV fragment: D = highest fragment-seq [46:48], modular-u16, skipping gaps/junk.
         frag = struct.unpack("<H", dec[46:48])[0]

--- a/custom_components/cuboai/tutk/cuboai_pure.py
+++ b/custom_components/cuboai/tutk/cuboai_pure.py
@@ -65,7 +65,6 @@ import time
 # It is a positional permutation (value-independent), so it generalises to any
 # host. Computing it dynamically keeps the pure transport portable across hosts.
 _AVMID_PERM     = (1, 0, 5, 4, 3, 2)
-_AVMID_FALLBACK = bytes.fromhex("000000000000")   # neutral fallback; used only iff the local MAC read fails
 _AF_PACKET      = 17       # sockaddr_ll.sll_family on Linux
 _AF_LINK        = 18       # sockaddr_dl.sdl_family on macOS/BSD
 _IFF_LOOPBACK   = 0x8      # net/if.h IFF_LOOPBACK — same value on Linux and macOS/BSD
@@ -194,17 +193,22 @@ def compute_av_mid():
     """Return the 6-byte _AV_MID for this host (perm of local NIC MAC).
 
     Cross-platform: getifaddrs (Linux AF_PACKET / macOS AF_LINK) → /sys/class/net
-    (Linux) → uuid.getnode() (Windows + universal). Falls back to a neutral value
-    only if every method fails, so import never raises; a stderr note is emitted
-    on that final fallback. On Linux/macOS getifaddrs wins.
+    (Linux) → uuid.getnode() (Windows + universal). If every method fails (e.g. a
+    network-isolated container with no NIC at all), a fresh random 6-byte fingerprint
+    is generated instead — the camera does not validate this value's structure or
+    origin, so any 6 bytes work equally well, and a random value avoids every such
+    host presenting the same fixed, identifiable fingerprint. Import never raises; a
+    stderr note is emitted on that fallback. On Linux/macOS getifaddrs wins, so
+    behaviour is unchanged.
     """
     mac = (_local_mac_via_getifaddrs()      # Linux (AF_PACKET) / macOS (AF_LINK)
            or _local_mac_via_sysfs()        # Linux /sys/class/net fallback
            or _local_mac_via_uuid())        # cross-platform incl. Windows
     if mac is None:
+        fallback = os.urandom(6)
         sys.stderr.write("[cuboai_pure] WARN: no NIC MAC found; "
-                         "using fallback _AV_MID %s\n" % _AVMID_FALLBACK.hex())
-        return _AVMID_FALLBACK
+                         "using random fallback _AV_MID %s\n" % fallback.hex())
+        return fallback
     return bytes(mac[i] for i in _AVMID_PERM)
 
 

--- a/custom_components/cuboai/tutk/cuboai_stream_playback.py
+++ b/custom_components/cuboai/tutk/cuboai_stream_playback.py
@@ -175,8 +175,13 @@ def main() -> int:
     # defer_stream_start=False matches the live producer: the engine brings its
     # reader up immediately instead of waiting out a ~5s native defer, which
     # would otherwise elapse before the first recorded frame is expected.
+    # auto_discover_lib=False: PlaybackSession is pure-only — it reaches through
+    # `transport._inner` (a PureSession attribute) and drives the pure engine's RDT
+    # and channel-N paths. A native session auto-discovered from libs/<arch>/ would
+    # not provide any of that, so pin the backend rather than depending on the
+    # camera_ip argument to incidentally rule the native library out.
     with get_session(uid, account, password, camera_ip=camera_ip,
-                     auto_discover_lib=True,
+                     auto_discover_lib=False,
                      defer_stream_start=False, defer_video_start_late=False) as sess:
         transport = sess
         inner = getattr(transport, "_inner", transport)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,22 @@ _ha_module(
     DataUpdateCoordinator=_DataUpdateCoordinator,
     UpdateFailed=type("UpdateFailed", (Exception,), {}),
 )
+_ha_module(
+    "homeassistant.components.number",
+    NumberEntity=_entity_base("NumberEntity"),
+    RestoreNumber=_entity_base("RestoreNumber"),
+)
+_ha_module(
+    "homeassistant.components.media_player",
+    MediaPlayerEntity=_entity_base("MediaPlayerEntity"),
+    MediaPlayerEntityFeature=MagicMock(),
+    MediaPlayerState=MagicMock(),
+    MediaType=MagicMock(),
+    RepeatMode=MagicMock(),
+)
+_ha_module("homeassistant.helpers.entity_registry", async_get=MagicMock())
+_ha_module("homeassistant.helpers.dispatcher", async_dispatcher_send=MagicMock(),
+           async_dispatcher_connect=MagicMock())
 _ha_module("homeassistant.exceptions", HomeAssistantError=RuntimeError)
 _ha_module("homeassistant.util")
 _ha_module("homeassistant.util.dt", utcnow=lambda: datetime.datetime.now(datetime.UTC))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,9 @@ This module sets up the necessary mocks for Home Assistant modules
 so that cuboai components can be imported in tests.
 """
 
+import datetime
 import sys
+from types import ModuleType
 from unittest.mock import MagicMock
 
 import pytest
@@ -22,6 +24,58 @@ sys.modules["homeassistant.const"] = MagicMock()
 sys.modules["homeassistant.helpers"] = MagicMock()
 sys.modules["homeassistant.helpers.entity"] = MagicMock()
 sys.modules["homeassistant.helpers.config_validation"] = MagicMock()
+
+# Entity base classes and exceptions must be REAL objects, not MagicMock attributes:
+# the platform modules subclass them (and combine several by multiple inheritance, so
+# they must also be distinct classes), and `except HomeAssistantError` needs a real
+# exception type. Registering them here rather than in individual test modules keeps
+# it independent of the order pytest happens to import tests in — a stub installed by
+# one test module was otherwise visible to, and could break, every later one.
+def _ha_module(name, **attrs):
+    """Ensure sys.modules[name] exists and carries `attrs`, without clobbering
+    anything a module already there has defined."""
+    mod = sys.modules.get(name)
+    if not isinstance(mod, ModuleType):
+        mod = ModuleType(name)
+        sys.modules[name] = mod
+    for key, value in attrs.items():
+        if not hasattr(mod, key):
+            setattr(mod, key, value)
+    return mod
+
+
+def _entity_base(name):
+    return type(name, (), {"__init__": lambda self, *a, **k: None})
+
+
+class _CoordinatorEntity:
+    """Mirrors the one behaviour the platform modules rely on from the real base:
+    `super().__init__(coordinator)` makes `self.coordinator` available."""
+
+    def __init__(self, coordinator=None, context=None):
+        self.coordinator = coordinator
+
+
+class _DataUpdateCoordinator:
+    def __init__(self, hass=None, logger=None, *, name=None, update_interval=None, **kwargs):
+        self.hass = hass
+        self.logger = logger
+        self.name = name
+        self.update_interval = update_interval
+
+
+_ha_module("homeassistant.components")
+_ha_module("homeassistant.components.switch", SwitchEntity=_entity_base("SwitchEntity"))
+_ha_module("homeassistant.helpers.restore_state", RestoreEntity=_entity_base("RestoreEntity"))
+_ha_module(
+    "homeassistant.helpers.update_coordinator",
+    CoordinatorEntity=_CoordinatorEntity,
+    DataUpdateCoordinator=_DataUpdateCoordinator,
+    UpdateFailed=type("UpdateFailed", (Exception,), {}),
+)
+_ha_module("homeassistant.exceptions", HomeAssistantError=RuntimeError)
+_ha_module("homeassistant.util")
+_ha_module("homeassistant.util.dt", utcnow=lambda: datetime.datetime.now(datetime.UTC))
 
 # Mock cuboai utils to avoid file I/O during tests
 _mock_utils = MagicMock()

--- a/tests/test_av_mid_fallback.py
+++ b/tests/test_av_mid_fallback.py
@@ -1,0 +1,53 @@
+"""The client fingerprint must not collapse to a shared constant on a NIC-less host.
+
+`_AV_MID` (the 6-byte client fingerprint in the probe and AV/DATA plaintext) is
+derived from the host NIC MAC. When every lookup fails — a network-isolated
+container with no NIC, which is a plausible shape for a Home Assistant add-on —
+the old code returned a hard-coded `000000000000`, so every such host presented
+the same fingerprint to its camera.
+
+The camera does not validate this value, so this is hardening rather than a
+crash fix; a random fallback simply keeps distinct hosts distinct.
+"""
+
+import importlib.util
+import os
+
+_TUTK = os.path.join(os.path.dirname(__file__), "..", "custom_components", "cuboai", "tutk")
+
+_spec = importlib.util.spec_from_file_location("live_pure_avmid", os.path.join(_TUTK, "cuboai_pure.py"))
+cp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cp)
+
+
+def test_normal_path_still_derives_from_the_nic_mac():
+    """On a host that has a NIC, nothing about this changes."""
+    mid = cp.compute_av_mid()
+    assert isinstance(mid, bytes) and len(mid) == 6
+    assert mid == cp.compute_av_mid(), "the MAC-derived fingerprint must be stable"
+
+
+def test_fallback_is_random_not_a_shared_constant(monkeypatch=None):
+    saved = (cp._local_mac_via_getifaddrs, cp._local_mac_via_sysfs, cp._local_mac_via_uuid)
+    try:
+        cp._local_mac_via_getifaddrs = lambda: None
+        cp._local_mac_via_sysfs = lambda: None
+        cp._local_mac_via_uuid = lambda: None
+        a = cp.compute_av_mid()
+        b = cp.compute_av_mid()
+        assert len(a) == len(b) == 6
+        assert a != bytes(6), "the fallback must not be the old all-zero constant"
+        assert a != b, "two NIC-less hosts must not present the same fingerprint"
+    finally:
+        (cp._local_mac_via_getifaddrs, cp._local_mac_via_sysfs, cp._local_mac_via_uuid) = saved
+
+
+def test_no_all_zero_constant_remains():
+    src = open(os.path.join(_TUTK, "cuboai_pure.py"), encoding="utf-8").read()
+    assert "_AVMID_FALLBACK" not in src
+
+
+if __name__ == "__main__":
+    for fn in sorted(k for k in dict(globals()) if k.startswith("test_")):
+        globals()[fn]()
+        print("ok:", fn)

--- a/tests/test_backend_consistency.py
+++ b/tests/test_backend_consistency.py
@@ -1,0 +1,101 @@
+"""Every in-process session must use the same transport backend.
+
+`async_ensure_dependencies` downloads an optional native `libIOTCAPIs_ALL.so`
+into `custom_components/cuboai/libs/<arch>/`, and that is one of the directories
+`cuboai_session._find_library()` searches. So a call site that leaves
+`auto_discover_lib` at its default (True) can silently land on the native
+backend while `switch.py`, `light.py` and the streamers — which pass False —
+stay on the pure transport.
+
+That split is currently masked by an incidental guard in `get_session`: a
+truthy `camera_ip` discards the discovered library. But the camera IP is
+auto-learned by the first successful poll, so a fresh install polls before it
+is known, and any setup where it stays unset keeps the split permanently. The
+DVR playback path is the sharpest case — `PlaybackSession` reaches through
+`transport._inner`, which only the pure session has.
+
+Pinning `auto_discover_lib=False` everywhere makes the backend a property of
+the integration rather than of whether a file happens to exist. An explicit
+`lib_path` (or CUBOAI_LIB) still selects the native backend.
+"""
+
+import io
+import os
+import re
+import tokenize
+
+_CC = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "custom_components", "cuboai")
+
+# The pure engine's own vendored copy is a separate upstream tree; it is not a
+# call site of this integration and is excluded from the sweep.
+_EXCLUDE_DIRS = {"playback_engine", "__pycache__"}
+
+
+def _python_files():
+    for root, dirs, files in os.walk(_CC):
+        dirs[:] = [d for d in dirs if d not in _EXCLUDE_DIRS]
+        for name in files:
+            if name.endswith(".py"):
+                yield os.path.join(root, name)
+
+
+def test_no_call_site_auto_discovers_a_native_library():
+    offenders = []
+    for path in _python_files():
+        src = open(path, encoding="utf-8").read()
+        for m in re.finditer(r"auto_discover_lib\s*=\s*True", src):
+            line = src[: m.start()].count("\n") + 1
+            # the parameter's own default in the factory signature is not a call site
+            if os.path.basename(path) == "cuboai_session.py":
+                continue
+            offenders.append(f"{os.path.relpath(path, _CC)}:{line}")
+    assert not offenders, (
+        "these call sites can auto-discover a native TUTK library and split the "
+        "backend away from the pure sessions used elsewhere: " + ", ".join(offenders)
+    )
+
+
+def test_every_get_session_call_site_pins_the_backend():
+    """A call site that omits the argument entirely inherits the True default,
+    which is the same hazard spelled differently.
+
+    Tokenised rather than regexed so comments and docstrings that merely mention
+    get_session() are not mistaken for call sites.
+    """
+    missing = []
+    for path in _python_files():
+        if os.path.basename(path) == "cuboai_session.py":
+            continue
+        src = open(path, encoding="utf-8").read()
+        try:
+            toks = list(tokenize.generate_tokens(io.StringIO(src).readline))
+        except (tokenize.TokenError, SyntaxError, IndentationError):
+            continue
+        code = [t for t in toks if t.type not in (tokenize.COMMENT, tokenize.NL, tokenize.NEWLINE)]
+        for i, t in enumerate(code):
+            if t.type != tokenize.NAME or t.string != "get_session":
+                continue
+            if i and code[i - 1].type == tokenize.OP and code[i - 1].string == ".":
+                continue                      # attribute access, e.g. self._get_session
+            if i + 1 >= len(code) or code[i + 1].string != "(":
+                continue                      # an import or a reference, not a call
+            depth, j, args = 0, i + 1, []
+            while j < len(code):
+                if code[j].string == "(":
+                    depth += 1
+                elif code[j].string == ")":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                else:
+                    args.append(code[j].string)
+                j += 1
+            if "auto_discover_lib" not in args:
+                missing.append(f"{os.path.relpath(path, _CC)}:{t.start[0]}")
+    assert not missing, "get_session call sites that do not pin auto_discover_lib: " + ", ".join(missing)
+
+
+if __name__ == "__main__":
+    for fn in sorted(k for k in dict(globals()) if k.startswith("test_")):
+        globals()[fn]()
+        print("ok:", fn)

--- a/tests/test_client_methods_exist.py
+++ b/tests/test_client_methods_exist.py
@@ -1,0 +1,111 @@
+"""Every `client.<method>()` the integration calls must exist on CuboAIClient.
+
+`coordinator.py` called `client.get_lullaby_schedule()`, which was never defined
+on `CuboAIClient`. Every poll raised AttributeError, the surrounding
+`except Exception` swallowed it, and the old hardcoded `lullaby_volume = 50`
+fallback made the result indistinguishable from a real reading — so the lullaby
+volume Home Assistant displayed was never once the camera's, and nothing
+anywhere said so.
+
+A missing method is invisible in this codebase because almost every camera read
+is wrapped in a broad except. This test re-derives both sets from the source, so
+a typo or a getter that was planned but never written fails here instead of
+silently degrading to a fallback for months.
+"""
+
+import ast
+import os
+import re
+
+_CC = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                   "custom_components", "cuboai")
+
+
+def _client_methods():
+    tree = ast.parse(open(os.path.join(_CC, "tutk", "cuboai_messages.py"), encoding="utf-8").read())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "CuboAIClient":
+            return {f.name for f in node.body if isinstance(f, ast.FunctionDef)}
+    raise AssertionError("CuboAIClient not found")
+
+
+def _called():
+    calls = {}
+    for name in sorted(os.listdir(_CC)):
+        if not name.endswith(".py"):
+            continue
+        text = open(os.path.join(_CC, name), encoding="utf-8").read()
+        for m in re.finditer(r"\bclient\.(\w+)\s*\(", text):
+            calls.setdefault(m.group(1), set()).add(name)
+    return calls
+
+
+def test_every_called_client_method_is_defined():
+    have = _client_methods()
+    missing = {k: sorted(v) for k, v in _called().items() if k not in have}
+    assert not missing, (
+        "these CuboAIClient methods are called but never defined, so every call raises "
+        "AttributeError and is swallowed by the surrounding except: "
+        + ", ".join(f"client.{k}() in {', '.join(v)}" for k, v in sorted(missing.items()))
+    )
+
+
+def test_the_call_set_is_not_trivially_empty():
+    """Guard the guard — if the pattern stops matching, the check above passes vacuously."""
+    calls = _called()
+    assert len(calls) > 10, f"only {len(calls)} client calls matched — the pattern has drifted"
+    assert "get_lullaby_schedule" in calls
+    assert "get_hw_control" in calls
+
+
+def test_get_lullaby_schedule_returns_the_volume_and_timer():
+    """The specific method that was missing, exercised end to end off a synthetic response."""
+    import importlib.util
+    import struct
+    import sys
+    from unittest.mock import MagicMock
+
+    spec = importlib.util.spec_from_file_location(
+        "cuboai_messages_client_test", os.path.join(_CC, "tutk", "cuboai_messages.py")
+    )
+    msgs = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = msgs
+    spec.loader.exec_module(msgs)
+
+    raw = bytearray(144)
+    struct.pack_into("<I", raw, 8, 1800)     # timer_mode: 30 minutes
+    struct.pack_into("<I", raw, 12, 42)      # volume
+    transport = MagicMock()
+    transport.ioctl.return_value = (msgs.IOTYPE_USER_GET_LULLABY_SCHEDULE_RESP, bytes(raw))
+
+    sched = msgs.CuboAIClient(transport).get_lullaby_schedule()
+    assert sched["volume"] == 42
+    assert sched["timer_mode"] == 1800
+    assert sched["timer"] == "30 min"
+
+
+def test_get_lullaby_schedule_rejects_a_mismatched_response_type():
+    import importlib.util
+    import sys
+    from unittest.mock import MagicMock
+
+    spec = importlib.util.spec_from_file_location(
+        "cuboai_messages_client_test2", os.path.join(_CC, "tutk", "cuboai_messages.py")
+    )
+    msgs = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = msgs
+    spec.loader.exec_module(msgs)
+
+    transport = MagicMock()
+    transport.ioctl.return_value = (9999, bytes(144))
+    try:
+        msgs.CuboAIClient(transport).get_lullaby_schedule()
+    except ValueError:
+        return
+    raise AssertionError("a mismatched response type should raise")
+
+
+if __name__ == "__main__":
+    for fn in sorted(k for k in dict(globals()) if k.startswith("test_")):
+        globals()[fn]()
+        print("ok:", fn)

--- a/tests/test_connection_mode_carry.py
+++ b/tests/test_connection_mode_carry.py
@@ -1,0 +1,90 @@
+"""A session-stats response with no parseable body must not erase the known mode.
+
+`parse_session_stats` returns a dict WITHOUT a 'mode' key whenever
+`_extract_json` cannot recover the embedded JSON from the response blob. The
+coordinator used to write `stats.get("mode")` unconditionally, so that None
+landed in `local_data` and the merge in `_fetch_all` — which exists to carry
+values forward across a failed read — dutifully overwrote the last good "lan"
+with nothing.
+
+Measured on a live camera over 12 hours: the Connection Mode sensor flapped to
+`unknown` 200 times, each lasting a median of 64.6s (exactly one poll), for a
+value that never actually changed. Every other failure path in
+`_fetch_local_data` leaves its key unset and is carried forward; this one call
+succeeded, so it escaped that protection.
+
+Unknown is never a true answer here in any case: this GET only returns at all
+because the local session to the camera is up.
+"""
+
+import importlib
+import importlib.util
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# The Home Assistant stubs the coordinator needs come from conftest. utils stays
+# conftest's mock — the coordinator only takes log_to_file from it.
+sys.modules.pop("custom_components.cuboai.coordinator", None)
+coordinator = importlib.import_module("custom_components.cuboai.coordinator")
+
+
+def _client(stats):
+    """A CuboAIClient whose getters all answer, with get_session_stats controlled."""
+    c = MagicMock()
+    c.get_session_stats.return_value = stats
+    return c
+
+
+def _session_ctx():
+    sess = MagicMock()
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=sess)
+    ctx.__exit__ = MagicMock(return_value=False)
+    return ctx
+
+
+def _fetch(stats):
+    client = _client(stats)
+    with patch("custom_components.cuboai.tutk.cuboai_session.get_session", return_value=_session_ctx()), \
+         patch("custom_components.cuboai.tutk.cuboai_messages.CuboAIClient", return_value=client):
+        return coordinator._fetch_local_data("uid", "acct", "pw", "192.0.2.10")
+
+
+def test_mode_is_reported_when_the_response_carries_one():
+    data = _fetch({"mode": "lan", "raw_len": 512})
+    assert data["connection_mode"] == "lan"
+
+
+def test_missing_mode_leaves_the_key_unset_so_the_last_value_carries():
+    """The key must be ABSENT, not None — absence is what the merge carries forward."""
+    data = _fetch({"raw_len": 96, "result": 0})
+    assert "connection_mode" not in data, "a None mode was written and will erase the good value"
+
+
+def test_none_mode_leaves_the_key_unset():
+    data = _fetch({"mode": None, "raw_len": 96})
+    assert "connection_mode" not in data
+
+
+def test_a_raised_get_also_leaves_the_key_unset():
+    """The pre-existing failure path, pinned alongside the new one."""
+    client = _client({})
+    client.get_session_stats.side_effect = RuntimeError("timeout")
+    with patch("custom_components.cuboai.tutk.cuboai_session.get_session", return_value=_session_ctx()), \
+         patch("custom_components.cuboai.tutk.cuboai_messages.CuboAIClient", return_value=client):
+        data = coordinator._fetch_local_data("uid", "acct", "pw", "192.0.2.10")
+    assert "connection_mode" not in data
+
+
+def test_the_merge_carries_an_absent_key_forward():
+    """The other half of the contract: _fetch_all merges onto the previous local
+    dict, so a key this poll did not set keeps its previous value."""
+    old_local = {"connection_mode": "lan", "temperature": 25.0}
+    local_data = {"temperature": 24.5}          # this poll had no mode
+    merged = old_local.copy()
+    merged.update(local_data)
+    assert merged["connection_mode"] == "lan"
+    assert merged["temperature"] == 24.5

--- a/tests/test_dataack_wrap.py
+++ b/tests/test_dataack_wrap.py
@@ -1,0 +1,98 @@
+"""The cumulative data-ACK must survive the u16 message-index wrap.
+
+The camera's reliable IO/control message-index (wire [56:58]) is a u16 that
+wraps 65535 -> 0. The host's cumulative ACK `_data_ack` (wire [40:42]) is
+advanced by contiguity over those indices, but it is an unbounded Python int.
+
+Once the index wraps, `(self._data_ack + 1) in self._cam_msgs` can never be
+true again, so `_data_ack` FREEZES at 65535: the D field of every subsequent
+host->cam ACK pins at 0xFFFF and stops crediting the camera's send window.
+At the observed IO-message rate that is reachable in a long-lived session, and
+nothing about the wire looks malformed while it happens.
+
+`tutk/playback_engine/cuboai_pure.py` already carries the fix; this pins it in
+the live copy. Same bug class as the `_idx_modular` fix that sits beside it.
+"""
+
+import importlib.util
+import os
+import struct
+
+_TUTK = os.path.join(os.path.dirname(__file__), "..", "custom_components", "cuboai", "tutk")
+
+_spec = importlib.util.spec_from_file_location("live_pure_dataack", os.path.join(_TUTK, "cuboai_pure.py"))
+cp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cp)
+
+WRAP = 1 << 16
+
+
+def _io_frame(idx):
+    """Minimal 68-byte camera DATA frame classified as a reliable IO/control response:
+    dec[56:58] = message-index (LE u16); dec[58:64] == 0 is the _is_io_frame discriminator."""
+    dec = bytearray(68)
+    struct.pack_into("<H", dec, 56, idx & 0xFFFF)
+    return bytes(dec)
+
+
+def _fresh(wrap):
+    """A bare session carrying only the attributes _note_cam_data's IO path touches."""
+    s = object.__new__(cp.TUTKDirectSession)   # bypass __init__: no handshake, no socket
+    s._dataack_wrap = bool(wrap)
+    s._cam_msgs = set()
+    s._data_ack = 0
+    s._got_first = False
+    return s
+
+
+def _feed(s, start_idx, count):
+    for k in range(count):
+        s._note_cam_data(_io_frame((start_idx + k) % WRAP))
+
+
+def test_wrap_on_crosses():
+    s = _fresh(wrap=True)
+    s._data_ack = 65529
+    _feed(s, 65530, 11)                    # idx 65530..65535 then 0..4 — crosses the wrap
+    assert s._data_ack == 65540, f"WRAP ON failed to cross the wrap: _data_ack={s._data_ack}"
+    assert s._data_ack & 0xFFFF == 4, "wire [40:42] should have wrapped to 0x0004"
+
+
+def test_wrap_off_freezes():
+    """Reproduces the bug, so the test proves the fix is what moves the needle."""
+    s = _fresh(wrap=False)
+    s._data_ack = 65529
+    _feed(s, 65530, 11)
+    assert s._data_ack == 65535, f"WRAP OFF should FREEZE at 65535, got {s._data_ack}"
+    assert s._data_ack & 0xFFFF == 0xFFFF
+
+
+def test_prewrap_is_byte_identical():
+    """Below the wrap the fix must change nothing at all — same _data_ack sequence
+    and the same bytes out of build_data_ack."""
+    on, off = _fresh(wrap=True), _fresh(wrap=False)
+    seq_on, seq_off = [], []
+    for i in range(1, 400):
+        on._note_cam_data(_io_frame(i))
+        off._note_cam_data(_io_frame(i))
+        seq_on.append(on._data_ack)
+        seq_off.append(off._data_ack)
+    assert seq_on == seq_off, "PRE-WRAP divergence between ON and OFF _data_ack sequences"
+    assert on._data_ack == 399
+    kw = {"R": 0x1234, "seq": 7, "relseq": 3, "ackord": 1, "C": 100, "D": 110, "sack": None}
+    assert cp.build_data_ack(data_ack=on._data_ack, **kw) == cp.build_data_ack(data_ack=off._data_ack, **kw)
+
+
+def test_consumed_indices_do_not_grow_without_bound():
+    """The ON path discards consumed entries, so _cam_msgs stays small on a
+    contiguous stream instead of retaining every index for the session's life."""
+    s = _fresh(wrap=True)
+    _feed(s, 1, 5000)
+    assert s._data_ack == 5000
+    assert len(s._cam_msgs) <= 1, f"_cam_msgs grew to {len(s._cam_msgs)} on a contiguous feed"
+
+
+if __name__ == "__main__":
+    for fn in sorted(k for k in dict(globals()) if k.startswith("test_")):
+        globals()[fn]()
+        print("ok:", fn)

--- a/tests/test_extract_json.py
+++ b/tests/test_extract_json.py
@@ -1,0 +1,120 @@
+"""The embedded-JSON extractor must not be defeated by trailing binary.
+
+Camera responses like GET_SESSION_STATS (0x0935) and GET_USER_LIST (0x0947) are
+binary IOCTL blobs with a JSON object somewhere inside them. The extractor used
+a greedy `\\{.*\\}` match, which spans from the FIRST '{' to the LAST '}'
+anywhere in the blob — so a single stray 0x7D byte among the trailing counters
+and padding swallowed everything after the real object and json.loads failed,
+discarding the whole response.
+
+Because the trailing bytes are counters, whether a 0x7D appeared there varied
+poll to poll. On a live camera that showed up as the Connection Mode sensor
+dropping to `unknown` for exactly one poll and recovering — roughly one poll in
+three, 200 times over 12 hours.
+
+Extraction is now brace-counted and string-aware, with the old greedy match kept
+as a fallback so this can only ever parse more responses than before, never
+fewer.
+"""
+
+import importlib.util
+import json
+import os
+import re
+import sys
+
+_TUTK = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                     "custom_components", "cuboai", "tutk")
+
+_spec = importlib.util.spec_from_file_location("cuboai_messages_under_test",
+                                               os.path.join(_TUTK, "cuboai_messages.py"))
+msgs = importlib.util.module_from_spec(_spec)
+# Registered before exec: the module defines @dataclass types, and dataclasses
+# resolves annotations through sys.modules[cls.__module__].
+sys.modules[_spec.name] = msgs
+_spec.loader.exec_module(msgs)
+
+
+def _greedy(raw: bytes):
+    """The previous implementation, for contrast."""
+    m = re.search(rb"\{.*\}", raw, re.S)
+    if not m:
+        return None
+    txt = m.group(0).decode("latin1", "replace")
+    txt = re.sub(r':\s*(\d{1,3}(?:\.\d{1,3}){3})\s*([,}\]])', r': "\1"\2', txt)
+    try:
+        return json.loads(txt)
+    except Exception:
+        return None
+
+
+HEADER = bytes(8)
+BODY = b'{"mode":"lan","nat":2,"ip":192.168.1.124,"session_id":3}'
+
+
+def test_plain_embedded_object_still_parses():
+    got = msgs._extract_json(HEADER + BODY)
+    assert got["mode"] == "lan"
+    assert got["ip"] == "192.168.1.124", "the bare dotted-quad repair must still apply"
+
+
+def test_trailing_binary_with_a_stray_close_brace():
+    """The failure mode, reproduced: 0x7D among the trailing counters."""
+    blob = HEADER + BODY + bytes([0x00, 0x11, 0x7D, 0x00, 0x04])
+    assert _greedy(blob) is None, "the old extractor should fail here (that was the bug)"
+    got = msgs._extract_json(blob)
+    assert got is not None and got["mode"] == "lan"
+
+
+def test_trailing_binary_without_a_stray_brace_is_unaffected():
+    """The other two-thirds of polls, which always worked."""
+    blob = HEADER + BODY + bytes([0x00, 0x11, 0x22, 0x00])
+    assert _greedy(blob) is not None
+    assert msgs._extract_json(blob)["mode"] == "lan"
+
+
+def test_a_brace_inside_a_string_does_not_close_the_object():
+    body = b'{"ssid":"my}wifi","mode":"lan"}'
+    got = msgs._extract_json(HEADER + body + b"\x7d\x00")
+    assert got == {"ssid": "my}wifi", "mode": "lan"}
+
+
+def test_an_escaped_quote_inside_a_string_is_handled():
+    body = rb'{"name":"a\"b}c","mode":"lan"}'
+    got = msgs._extract_json(HEADER + body + b"\x00\x7d")
+    assert got["mode"] == "lan"
+
+
+def test_nested_objects_are_spanned_whole():
+    body = b'{"a_frame":[{"frm_count":12}],"mode":"lan"}'
+    got = msgs._extract_json(HEADER + body + b"\x7d")
+    assert got["mode"] == "lan"
+    assert got["a_frame"][0]["frm_count"] == 12
+
+
+def test_first_object_wins_when_the_blob_holds_two():
+    blob = HEADER + b'{"mode":"lan"}' + bytes(4) + b'{"mode":"relay"}'
+    assert msgs._extract_json(blob)["mode"] == "lan"
+
+
+def test_truncated_object_returns_none():
+    assert msgs._extract_json(HEADER + b'{"mode":"la') is None
+
+
+def test_no_json_at_all_returns_none():
+    assert msgs._extract_json(bytes(64)) is None
+
+
+def test_session_stats_recovers_the_mode_through_the_parser():
+    """End to end: the symptom that started this was parse_session_stats
+    returning a dict with no 'mode' key."""
+    blob = HEADER + BODY + bytes([0x7D, 0x00, 0x03])
+    parsed = msgs.parse_session_stats(blob)
+    assert parsed["mode"] == "lan"
+    assert parsed["ip"] == "192.168.1.124"
+
+
+if __name__ == "__main__":
+    for fn in sorted(k for k in dict(globals()) if k.startswith("test_")):
+        globals()[fn]()
+        print("ok:", fn)

--- a/tests/test_go2rtc_config_streams.py
+++ b/tests/test_go2rtc_config_streams.py
@@ -1,0 +1,98 @@
+"""go2rtc.yaml is regenerated, and its stream set must be exactly ours.
+
+`_generate_config` builds `config` from scratch and `_write` truncates the file,
+so the written stream set is whatever `self._streams` holds — nothing is carried
+over from the previous file.
+
+The code used to claim otherwise: a comment described the file as "merged into,
+not replaced", and a loop pruned stale `cuboai_*` entries from
+`config["streams"]`. That key was always empty when the loop ran, so it could
+never do anything. These tests pin the behaviour that is actually wanted —
+regeneration with no leftovers — so a future attempt to reintroduce merging has
+to confront the stale-entry question deliberately.
+"""
+
+import importlib.util
+import os
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import yaml
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _load_go2rtc():
+    for name in ("homeassistant.components", "homeassistant.helpers.aiohttp_client"):
+        sys.modules.setdefault(name, ModuleType(name))
+    path = os.path.join(_ROOT, "custom_components", "cuboai", "go2rtc.py")
+    spec = importlib.util.spec_from_file_location("custom_components.cuboai.go2rtc", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+go2rtc = _load_go2rtc()
+
+
+class _Hass:
+    """Just enough hass for _generate_config: it only uses the executor."""
+
+    def __init__(self):
+        self.data = {}
+
+    async def async_add_executor_job(self, fn, *args):
+        return fn(*args)
+
+
+def _manager(tmp_path, streams, options=None):
+    m = object.__new__(go2rtc.Go2RTCManager)
+    m.hass = _Hass()
+    m._config_path = str(tmp_path / "go2rtc.yaml")
+    m._options = options or {}
+    m._streams = streams
+    m._rtsp_port = 8557
+    m._webrtc_port = 8556
+    m._api_port = 1985
+    m._LOGGER = MagicMock()
+    return m
+
+
+async def _write_config(tmp_path, streams, options=None):
+    m = _manager(tmp_path, streams, options)
+    await m._generate_config()
+    with open(m._config_path) as f:
+        return yaml.safe_load(f)
+
+
+async def test_written_streams_are_exactly_the_generated_set(tmp_path):
+    streams = {"cuboai_combined_A": "exec:one", "cuboai_dvr_A": "exec:two"}
+    cfg = await _write_config(tmp_path, streams)
+    assert cfg["streams"] == streams
+
+
+async def test_a_stream_we_no_longer_generate_does_not_survive(tmp_path):
+    """The regression the removed loop was aiming at, asserted end to end."""
+    first = await _write_config(tmp_path, {"cuboai_combined_A": "exec:one", "cuboai_old_A": "exec:stale"})
+    assert "cuboai_old_A" in first["streams"]
+
+    second = await _write_config(tmp_path, {"cuboai_combined_A": "exec:one"})
+    assert "cuboai_old_A" not in second["streams"], "a dropped stream survived regeneration"
+    assert second["streams"] == {"cuboai_combined_A": "exec:one"}
+
+
+async def test_ports_are_written_from_the_resolved_values(tmp_path):
+    cfg = await _write_config(tmp_path, {})
+    assert cfg["api"]["listen"] == ":1985"
+    assert cfg["rtsp"]["listen"] == ":8557"
+    assert cfg["webrtc"]["listen"] == ":8556"
+
+
+async def test_nvr_credentials_are_written_only_when_both_are_set(tmp_path):
+    cfg = await _write_config(tmp_path, {}, {"nvr_enabled": True, "nvr_password": "s3cret"})
+    assert cfg["rtsp"]["username"] == "cuboai"
+    assert cfg["rtsp"]["password"] == "s3cret"
+
+    cfg = await _write_config(tmp_path, {}, {"nvr_enabled": True})
+    assert "password" not in cfg["rtsp"]

--- a/tests/test_idx_seed.py
+++ b/tests/test_idx_seed.py
@@ -1,0 +1,144 @@
+"""A stream read that starts mid-session must not silently emit zero frames.
+
+`_av_reader`'s `done_upto` is a per-reader local that starts at -1, but the
+camera's AV message-index is SESSION-scoped and keeps advancing. So the FIRST
+read of a session works, and any read that begins once the index is past the
+`done_upto + 256` accept window rejects EVERY fragment — forever, and silently:
+fragments keep arriving at full rate while zero access units come out, and no
+error, gap counter or incomplete-AU counter moves.
+
+Reachable through the legacy shim: `cuboai_transport_py.start_video()` opens a
+fresh `av_frames()` iterator on each call, so calling it twice on one session
+lands exactly here. `tutk/playback_engine/cuboai_pure.py` already carries the
+fix (its DVR reader restores the live stream after playback and hits this on
+every restore); this pins it in the live copy.
+
+Fixture replays cannot catch this — every fixture starts at index ~0, inside
+the window — so this drives the real `_av_reader` over a real UDP socketpair
+with a synthetic camera whose message-index starts above the window, and
+asserts the gate FLIPS the outcome.
+"""
+
+import importlib.util
+import os
+import queue
+import socket
+import struct
+import threading
+import time
+
+_TUTK = os.path.join(os.path.dirname(__file__), "..", "custom_components", "cuboai", "tutk")
+
+_spec = importlib.util.spec_from_file_location("live_pure_seed", os.path.join(_TUTK, "cuboai_pure.py"))
+cp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cp)
+
+
+def _build_av_frag(idx, frag, payload, channel=0):
+    """One camera AV DATA fragment, wire-encoded. Layout per _av_reader: [28]=0x0C sub,
+    [46:48]=fragment-seq, [52:54]=avlen, [56:58]=AV message-index, [58:64]!=0 (AV, not a
+    reliable-IO frame), payload at [64:]."""
+    dec = bytearray(64 + len(payload))
+    dec[8:12] = b"\x08\x04\x12\x00"
+    dec[14] = channel
+    dec[28] = 0x0C
+    struct.pack_into("<H", dec, 46, frag & 0xFFFF)
+    struct.pack_into("<H", dec, 52, len(payload))
+    struct.pack_into("<H", dec, 56, idx & 0xFFFF)
+    dec[58:64] = b"\x01\x00\x00\x00\x00\x00"          # non-zero AV-unit id => not an IO frame
+    dec[64:] = payload
+    return cp.transcode(bytes(dec))
+
+
+def _run_reader(start_idx, n_aus, seed_gate):
+    """Drive the REAL _av_reader with a synthetic camera on loopback."""
+    os.environ["CUBOAI_IDX_SEED"] = "1" if seed_gate else "0"
+    for k in ("CUBOAI_NODROP", "CUBOAI_KF_GRACE", "CUBOAI_GRACE_SCALE", "CUBOAI_EMIT_COMPLETE"):
+        os.environ.pop(k, None)
+    try:
+        sess = cp.TUTKDirectSession()
+        sess._R = 0x1234
+        sess.session_hdr = bytes(16)
+
+        cam = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        cam.bind(("127.0.0.1", 0))
+        cli = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        cli.bind(("127.0.0.1", 0))
+        cli.setblocking(False)
+        sess._sock = cli
+        sess._cam = cam.getsockname()
+
+        out_q = queue.Queue(maxsize=600)
+        stop_evt = threading.Event()
+        th = threading.Thread(target=sess._av_reader, args=(cli, out_q, stop_evt), daemon=True)
+        th.start()
+
+        # One single-fragment video AU per message-index; +16 trailing AUs so the grace
+        # window releases everything under test regardless of the configured _MSG_GRACE.
+        au = b"\x00\x00\x00\x01\x26\x01\xAF" + b"\xAA" * 40   # start code + HEVC IDR_W_RADL
+        for i in range(n_aus + 16):
+            cam.sendto(_build_av_frag(start_idx + i, start_idx + i, au), cli.getsockname())
+            time.sleep(0.002)
+        time.sleep(1.2)
+        stop_evt.set()
+        th.join(timeout=2.0)
+
+        got = []
+        while True:
+            try:
+                item = out_q.get_nowait()
+            except queue.Empty:
+                break
+            if item is not None:
+                got.append(item)
+        stats = sess.get_stats()
+        cam.close()
+        cli.close()
+        return [u for kind, u, _f in got if kind == "video"], stats
+    finally:
+        os.environ.pop("CUBOAI_IDX_SEED", None)
+
+
+def test_gate_defaults_on():
+    os.environ.pop("CUBOAI_IDX_SEED", None)
+    assert cp.TUTKDirectSession()._idx_seed is True
+
+
+def test_fresh_session_path_is_unchanged():
+    """Index starts inside the window — the normal first-read case. The seed must
+    not fire, so ON and OFF have to produce byte-identical output."""
+    on, _ = _run_reader(0, 24, True)
+    off, _ = _run_reader(0, 24, False)
+    assert len(on) > 0, "gate ON emitted no AUs on the normal path"
+    assert len(off) > 0, "gate OFF emitted no AUs on the normal path"
+    assert on == off, "the seed changed the fresh-session path — it must be a no-op there"
+
+
+def test_mid_session_read_is_dead_without_the_fix_and_alive_with_it():
+    """Index starts beyond the window — a second read of a live session."""
+    off, s_off = _run_reader(5000, 24, False)
+    on, _ = _run_reader(5000, 24, True)
+    assert len(off) == 0, f"gate OFF should emit ZERO AUs (the bug); got {len(off)}"
+    assert s_off["frags_recv"] > 0, "the failure must be silent — fragments still arrive"
+    assert len(on) > 0, "gate ON should emit AUs"
+
+
+def test_mid_session_output_matches_the_in_window_output():
+    on_mid, _ = _run_reader(5000, 24, True)
+    on_fresh, _ = _run_reader(0, 24, True)
+    assert on_mid == on_fresh, "a mid-session read must yield the same AUs as a fresh one"
+
+
+def test_survives_a_start_just_below_the_u16_wrap():
+    on, _ = _run_reader(65530, 24, True)
+    assert len(on) > 0, "gate ON emitted no AUs across the 65535->0 wrap"
+
+
+if __name__ == "__main__":
+    for fn in ("test_gate_defaults_on",
+               "test_fresh_session_path_is_unchanged",
+               "test_mid_session_read_is_dead_without_the_fix_and_alive_with_it",
+               "test_mid_session_output_matches_the_in_window_output",
+               "test_survives_a_start_just_below_the_u16_wrap"):
+        globals()[fn]()
+        print("ok:", fn)

--- a/tests/test_local_keys_reconcile.py
+++ b/tests/test_local_keys_reconcile.py
@@ -1,0 +1,78 @@
+"""Every value an entity reads must be one the poll actually writes.
+
+The integration passes camera state around as a plain dict at
+`coordinator.data["cameras"][id]["local"]`. Nothing checks that the key an
+entity reads is the key the coordinator writes, so a typo or a never-implemented
+poll is invisible: the entity just returns its fallback forever.
+
+Two of these were live at once:
+
+  * `status_led_on` — the Status LED switch read it; the poll writes
+    `status_light_on`. The switch never reflected the camera and sat at False.
+  * `brightness` — the Night Light Brightness number and the light entity read
+    it; nothing anywhere wrote it, because no code called GET_LIGHT_STYLE. The
+    number reported a hardcoded 100 forever.
+  * `sleep_safety_raw` — the Sleep Safety sensor exposed it as an attribute;
+    nothing wrote it, so the attribute was always None.
+
+This test re-derives the read set and the written set from the source and fails
+on any key that is read but never written.
+"""
+
+import os
+import re
+
+_CC = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                   "custom_components", "cuboai")
+
+_READ_PATTERNS = (
+    r'get\(\s*"local"\s*,\s*\{\}\s*\)\s*\.get\(\s*"(\w+)"',
+    r'\(\s*cam\.get\("local"\)\s*or\s*\{\}\s*\)\.get\(\s*"(\w+)"',
+    r'\blocal\.get\(\s*"(\w+)"',
+)
+#: Only the coordinator's poll counts as a real write. An optimistic update after
+#: a SET does put the key in the dict, but it never reconciles with the camera —
+#: which is exactly how `status_led_on` hid: the switch wrote it on every toggle
+#: and read it back, while the poll wrote `status_light_on` that nothing read.
+_POLL_WRITE_PATTERN = r'\bdata\[\s*"(\w+)"\s*\]\s*='
+
+
+def _sources():
+    for name in sorted(os.listdir(_CC)):
+        if name.endswith(".py"):
+            yield name, open(os.path.join(_CC, name), encoding="utf-8").read()
+
+
+def _collect(patterns):
+    found = {}
+    for name, text in _sources():
+        for pat in patterns:
+            for m in re.finditer(pat, text):
+                found.setdefault(m.group(1), set()).add(name)
+    return found
+
+
+def test_no_entity_reads_a_key_the_poll_never_writes():
+    reads = _collect(_READ_PATTERNS)
+    polled = _collect((_POLL_WRITE_PATTERN,))
+    orphans = {k: sorted(v) for k, v in reads.items()
+               if k not in polled}
+    assert not orphans, (
+        "these keys are read by an entity but never written by the coordinator "
+        "poll, so the entity never reconciles with the camera: "
+        + ", ".join(f"{k} (read in {', '.join(v)})" for k, v in sorted(orphans.items()))
+    )
+
+
+def test_the_read_set_is_not_trivially_empty():
+    """Guard the guard: if the patterns stop matching, the test above passes vacuously."""
+    reads = _collect(_READ_PATTERNS)
+    assert len(reads) > 30, f"only {len(reads)} local keys matched — the patterns have drifted"
+    for expected in ("temperature", "humidity", "brightness", "status_light_on"):
+        assert expected in reads, f"{expected} should be read by some entity"
+
+
+if __name__ == "__main__":
+    for fn in sorted(k for k in dict(globals()) if k.startswith("test_")):
+        globals()[fn]()
+        print("ok:", fn)

--- a/tests/test_lullaby_timer.py
+++ b/tests/test_lullaby_timer.py
@@ -19,6 +19,7 @@ constant silently changed the field the user did not touch.
 import importlib
 import importlib.util
 import os
+import struct
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -94,114 +95,111 @@ def test_camera_value_wins_again_after_the_pending_clears():
 
 
 # --- the coupled write -------------------------------------------------------
+#
+# SET_LULLABY_VOL_DURATION (2438) is the camera's ONLY write for the lullaby
+# volume and sleep timer, and its 140-byte struct carries BOTH fields with no
+# field mask — there is no volume-only or timer-only opcode. Every write is
+# therefore a read-modify-write, and these tests decode the REAL payload the
+# real builder produces rather than mocking it.
 
-def _run_volume_cmd(volume, timer, sched_volume=70, sched_timer=1800):
-    """Drive _execute_lullaby_cmd's 'volume' branch and capture the frame built."""
-    client = MagicMock()
-    client.get_lullaby_schedule.return_value = MagicMock(volume=sched_volume, timer_mode=sched_timer)
+GET_SCHED_REQ, GET_SCHED_RESP, SET_VOL_DUR_REQ = 2440, 2441, 2438
+
+
+def _echo(volume, timer_seconds):
+    """A GET_LULLABY_SCHEDULE response: timer_mode @8, volume @12, playing @16."""
+    raw = bytearray(144)
+    struct.pack_into("<I", raw, 8, timer_seconds)
+    struct.pack_into("<I", raw, 12, volume)
+    struct.pack_into("<I", raw, 16, 1)
+    return bytes(raw)
+
+
+def _run_cmd(cmd_type, volume, timer, cam_volume=70, cam_timer=1800, echo_fails=False):
+    """Drive _execute_lullaby_cmd and decode the SET payload it actually built."""
+    sent = {}
+
+    def _ioctl(op, payload):
+        if op == GET_SCHED_REQ:
+            if echo_fails:
+                raise RuntimeError("timeout")
+            return GET_SCHED_RESP, _echo(cam_volume, cam_timer)
+        if op == SET_VOL_DUR_REQ:
+            sent["timer"] = struct.unpack_from("<I", payload, 4)[0]
+            sent["volume"] = struct.unpack_from("<I", payload, 8)[0]
+            sent["len"] = len(payload)
+        return op + 1, b""
+
     sess = MagicMock()
+    sess.ioctl.side_effect = _ioctl
     ctx = MagicMock()
     ctx.__enter__ = MagicMock(return_value=sess)
     ctx.__exit__ = MagicMock(return_value=False)
-    seen = {}
-
-    def _build(vol, tmr, correlation_id=0):
-        seen["volume"], seen["timer"] = vol, tmr
-        return 2438, b""
 
     with patch("custom_components.cuboai.tutk.cuboai_session.get_session", return_value=ctx), \
-         patch("custom_components.cuboai.tutk.cuboai_messages.CuboAIClient", return_value=client), \
-         patch("custom_components.cuboai.tutk.cuboai_messages.build_set_lullaby_vol_duration", _build):
+         patch("custom_components.cuboai.tutk.cuboai_messages.CuboAIClient", return_value=MagicMock()):
         media_player._execute_lullaby_cmd(
-            "uid", "acct", "pw", "192.0.2.10", "volume", None, volume, timer
+            "uid", "acct", "pw", "192.0.2.10", cmd_type, "SOME-UUID", volume, timer
         )
-    return seen
+    return sent
+
+
+def test_the_write_is_the_140_byte_coupled_struct():
+    sent = _run_cmd("volume", volume=80, timer=None)
+    assert sent["len"] == 140, "SET_LULLABY_VOL_DURATION is a fixed 140-byte struct"
 
 
 def test_setting_volume_alone_preserves_the_cameras_timer():
-    seen = _run_volume_cmd(volume=80, timer=None, sched_timer=1800)
-    assert seen["volume"] == 80
-    assert seen["timer"] == 1800, "changing the volume must not reset the sleep timer"
+    sent = _run_cmd("volume", volume=80, timer=None, cam_timer=1800)
+    assert sent["volume"] == 80
+    assert sent["timer"] == 1800, "changing the volume must not reset the sleep timer"
 
 
 def test_setting_the_timer_alone_preserves_the_cameras_volume():
-    seen = _run_volume_cmd(volume=None, timer=60, sched_volume=70)
-    assert seen["timer"] == 3600
-    assert seen["volume"] == 70, "changing the timer must not reset the volume"
+    sent = _run_cmd("volume", volume=None, timer=60, cam_volume=70)
+    assert sent["timer"] == 3600
+    assert sent["volume"] == 70, "changing the timer must not reset the volume"
 
 
 def test_zero_minutes_still_means_repeat_forever():
-    seen = _run_volume_cmd(volume=None, timer=0, sched_timer=1800)
-    assert seen["timer"] == 0
+    sent = _run_cmd("volume", volume=None, timer=0, cam_timer=1800)
+    assert sent["timer"] == 0
 
 
 def test_both_supplied_are_both_honoured():
-    seen = _run_volume_cmd(volume=25, timer=30)
-    assert (seen["volume"], seen["timer"]) == (25, 1800)
+    sent = _run_cmd("volume", volume=25, timer=30)
+    assert (sent["volume"], sent["timer"]) == (25, 1800)
 
 
-def test_unreadable_schedule_still_writes_something_sane():
-    client = MagicMock()
-    client.get_lullaby_schedule.side_effect = RuntimeError("timeout")
-    sess = MagicMock()
-    ctx = MagicMock()
-    ctx.__enter__ = MagicMock(return_value=sess)
-    ctx.__exit__ = MagicMock(return_value=False)
-    seen = {}
+def test_minutes_are_converted_to_the_cameras_seconds_encoding():
+    assert _run_cmd("volume", None, 30)["timer"] == 1800
+    assert _run_cmd("volume", None, 60)["timer"] == 3600
 
-    def _build(vol, tmr, correlation_id=0):
-        seen["volume"], seen["timer"] = vol, tmr
-        return 2438, b""
 
-    with patch("custom_components.cuboai.tutk.cuboai_session.get_session", return_value=ctx), \
-         patch("custom_components.cuboai.tutk.cuboai_messages.CuboAIClient", return_value=client), \
-         patch("custom_components.cuboai.tutk.cuboai_messages.build_set_lullaby_vol_duration", _build):
-        media_player._execute_lullaby_cmd("uid", "acct", "pw", "192.0.2.10", "volume", None, 80, None)
-    assert seen["volume"] == 80
-    assert seen["timer"] == 0
+def test_an_unreadable_echo_still_writes_the_supplied_field():
+    sent = _run_cmd("volume", volume=80, timer=None, echo_fails=True)
+    assert sent["volume"] == 80
+    assert sent["timer"] == 0, "with no echo to preserve, the timer falls back to repeat"
 
 
 # --- play must not reset the volume -----------------------------------------
 
-def _run_play_cmd(volume, timer, sched_volume=70):
-    client = MagicMock()
-    client.get_lullaby_schedule.return_value = MagicMock(volume=sched_volume, timer_mode=0)
-    sess = MagicMock()
-    ctx = MagicMock()
-    ctx.__enter__ = MagicMock(return_value=sess)
-    ctx.__exit__ = MagicMock(return_value=False)
-    seen = {}
-
-    def _build(vol, tmr, correlation_id=0):
-        seen["volume"], seen["timer"] = vol, tmr
-        return 2438, b""
-
-    with patch("custom_components.cuboai.tutk.cuboai_session.get_session", return_value=ctx), \
-         patch("custom_components.cuboai.tutk.cuboai_messages.CuboAIClient", return_value=client), \
-         patch("custom_components.cuboai.tutk.cuboai_messages.build_set_lullaby_vol_duration", _build):
-        media_player._execute_lullaby_cmd(
-            "uid", "acct", "pw", "192.0.2.10", "play", "SOME-UUID", volume, timer
-        )
-    return seen
-
-
 def test_play_keeps_the_cameras_volume_when_none_is_supplied():
     """Both callers pass volume=None; play must not silently reset it to 50."""
-    seen = _run_play_cmd(volume=None, timer=None, sched_volume=70)
-    assert seen["volume"] == 70
+    sent = _run_cmd("play", volume=None, timer=None, cam_volume=70)
+    assert sent["volume"] == 70
 
 
 def test_play_honours_an_explicit_volume():
-    seen = _run_play_cmd(volume=20, timer=None, sched_volume=70)
-    assert seen["volume"] == 20
+    sent = _run_cmd("play", volume=20, timer=None, cam_volume=70)
+    assert sent["volume"] == 20
 
 
 def test_play_with_no_timer_is_repeat_forever():
     """The card path relies on this: HA enforces the duration and sends the stop."""
-    seen = _run_play_cmd(volume=None, timer=None)
-    assert seen["timer"] == 0
+    sent = _run_cmd("play", volume=None, timer=None, cam_timer=1800)
+    assert sent["timer"] == 0
 
 
 def test_play_converts_minutes_to_the_cameras_seconds_encoding():
-    seen = _run_play_cmd(volume=None, timer=30)
-    assert seen["timer"] == 1800
+    sent = _run_cmd("play", volume=None, timer=30)
+    assert sent["timer"] == 1800

--- a/tests/test_lullaby_timer.py
+++ b/tests/test_lullaby_timer.py
@@ -1,0 +1,161 @@
+"""The Lullaby Timer must report what the camera is actually set to.
+
+`CuboLullabyTimerNumber` used to return a purely local value: it started at a
+hardcoded 30, was restored across reloads, and was never reconciled with the
+camera. So a lullaby the camera was repeating indefinitely still showed as
+"30 min" in Home Assistant — the mismatch that prompted this.
+
+The camera reports its real sleep timer on GET_LULLABY_SCHEDULE (timer_mode @8:
+0 = repeat forever, 1800 = 30 min, 3600 = 60 min), which the coordinator already
+calls for the volume and was discarding. It now surfaces it, and the entity
+reads it, keeping a locally-picked value as `pending` only until the camera
+confirms — so a pick made before pressing play is not clobbered by the next poll.
+
+Also covers the coupled-write hazard: SET_LULLABY_VOL_DURATION carries volume
+AND timer in one struct, so supplying only one and defaulting the other to a
+constant silently changed the field the user did not touch.
+"""
+
+import importlib
+import importlib.util
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# The real utils module, so @retry_camera_command stays a real decorator.
+_uspec = importlib.util.spec_from_file_location(
+    "custom_components.cuboai.utils", os.path.join(_ROOT, "custom_components", "cuboai", "utils.py")
+)
+_utils = importlib.util.module_from_spec(_uspec)
+sys.modules["custom_components.cuboai.utils"] = _utils
+_uspec.loader.exec_module(_utils)
+
+for _m in ("custom_components.cuboai.number", "custom_components.cuboai.media_player"):
+    sys.modules.pop(_m, None)
+number = importlib.import_module("custom_components.cuboai.number")
+media_player = importlib.import_module("custom_components.cuboai.media_player")
+
+
+DEVICE = "SW05TESTDEVICE01"
+
+
+def _entity(camera_local):
+    e = object.__new__(number.CuboLullabyTimerNumber)
+    e.coordinator = MagicMock()
+    e.coordinator.data = {"cameras": {DEVICE: {"local": camera_local}}}
+    e._device_id = DEVICE
+    e._timer_value = 30          # the old hardcoded local default
+    e._pending = None
+    e.async_write_ha_state = lambda: None
+    return e
+
+
+def test_reports_repeat_when_the_camera_is_on_repeat():
+    """The exact reported symptom: camera indefinite, HA said 30."""
+    e = _entity({"lullaby_timer_minutes": 0, "lullaby_timer_name": "repeat"})
+    assert e.native_value == 0
+    assert e.extra_state_attributes["camera_timer_mode"] == "repeat"
+
+
+def test_reports_the_cameras_thirty_minute_timer():
+    e = _entity({"lullaby_timer_minutes": 30, "lullaby_timer_name": "30min"})
+    assert e.native_value == 30
+
+
+def test_falls_back_to_the_restored_local_value_when_the_camera_is_silent():
+    e = _entity({})
+    assert e.native_value == 30
+
+
+def test_a_fresh_pick_survives_the_next_poll():
+    """Selecting 60 while the camera still says repeat must show 60, not 0."""
+    e = _entity({"lullaby_timer_minutes": 0})
+    e._pending = 60
+    assert e.native_value == 60
+    assert e.extra_state_attributes["differs_from_camera"] is True
+
+
+def test_pending_clears_once_the_camera_agrees():
+    e = _entity({"lullaby_timer_minutes": 60})
+    e._pending = 60
+    assert e.native_value == 60
+    assert e._pending is None, "pending should clear when the camera catches up"
+    assert e.extra_state_attributes["differs_from_camera"] is False
+
+
+def test_camera_value_wins_again_after_the_pending_clears():
+    e = _entity({"lullaby_timer_minutes": 60})
+    e._pending = 60
+    assert e.native_value == 60                      # reading it clears pending
+    e.coordinator.data["cameras"][DEVICE]["local"]["lullaby_timer_minutes"] = 0
+    assert e.native_value == 0
+
+
+# --- the coupled write -------------------------------------------------------
+
+def _run_volume_cmd(volume, timer, sched_volume=70, sched_timer=1800):
+    """Drive _execute_lullaby_cmd's 'volume' branch and capture the frame built."""
+    client = MagicMock()
+    client.get_lullaby_schedule.return_value = MagicMock(volume=sched_volume, timer_mode=sched_timer)
+    sess = MagicMock()
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=sess)
+    ctx.__exit__ = MagicMock(return_value=False)
+    seen = {}
+
+    def _build(vol, tmr, correlation_id=0):
+        seen["volume"], seen["timer"] = vol, tmr
+        return 2438, b""
+
+    with patch("custom_components.cuboai.tutk.cuboai_session.get_session", return_value=ctx), \
+         patch("custom_components.cuboai.tutk.cuboai_messages.CuboAIClient", return_value=client), \
+         patch("custom_components.cuboai.tutk.cuboai_messages.build_set_lullaby_vol_duration", _build):
+        media_player._execute_lullaby_cmd(
+            "uid", "acct", "pw", "192.0.2.10", "volume", None, volume, timer
+        )
+    return seen
+
+
+def test_setting_volume_alone_preserves_the_cameras_timer():
+    seen = _run_volume_cmd(volume=80, timer=None, sched_timer=1800)
+    assert seen["volume"] == 80
+    assert seen["timer"] == 1800, "changing the volume must not reset the sleep timer"
+
+
+def test_setting_the_timer_alone_preserves_the_cameras_volume():
+    seen = _run_volume_cmd(volume=None, timer=60, sched_volume=70)
+    assert seen["timer"] == 3600
+    assert seen["volume"] == 70, "changing the timer must not reset the volume"
+
+
+def test_zero_minutes_still_means_repeat_forever():
+    seen = _run_volume_cmd(volume=None, timer=0, sched_timer=1800)
+    assert seen["timer"] == 0
+
+
+def test_both_supplied_are_both_honoured():
+    seen = _run_volume_cmd(volume=25, timer=30)
+    assert (seen["volume"], seen["timer"]) == (25, 1800)
+
+
+def test_unreadable_schedule_still_writes_something_sane():
+    client = MagicMock()
+    client.get_lullaby_schedule.side_effect = RuntimeError("timeout")
+    sess = MagicMock()
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=sess)
+    ctx.__exit__ = MagicMock(return_value=False)
+    seen = {}
+
+    def _build(vol, tmr, correlation_id=0):
+        seen["volume"], seen["timer"] = vol, tmr
+        return 2438, b""
+
+    with patch("custom_components.cuboai.tutk.cuboai_session.get_session", return_value=ctx), \
+         patch("custom_components.cuboai.tutk.cuboai_messages.CuboAIClient", return_value=client), \
+         patch("custom_components.cuboai.tutk.cuboai_messages.build_set_lullaby_vol_duration", _build):
+        media_player._execute_lullaby_cmd("uid", "acct", "pw", "192.0.2.10", "volume", None, 80, None)
+    assert seen["volume"] == 80
+    assert seen["timer"] == 0

--- a/tests/test_lullaby_timer.py
+++ b/tests/test_lullaby_timer.py
@@ -159,3 +159,49 @@ def test_unreadable_schedule_still_writes_something_sane():
         media_player._execute_lullaby_cmd("uid", "acct", "pw", "192.0.2.10", "volume", None, 80, None)
     assert seen["volume"] == 80
     assert seen["timer"] == 0
+
+
+# --- play must not reset the volume -----------------------------------------
+
+def _run_play_cmd(volume, timer, sched_volume=70):
+    client = MagicMock()
+    client.get_lullaby_schedule.return_value = MagicMock(volume=sched_volume, timer_mode=0)
+    sess = MagicMock()
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=sess)
+    ctx.__exit__ = MagicMock(return_value=False)
+    seen = {}
+
+    def _build(vol, tmr, correlation_id=0):
+        seen["volume"], seen["timer"] = vol, tmr
+        return 2438, b""
+
+    with patch("custom_components.cuboai.tutk.cuboai_session.get_session", return_value=ctx), \
+         patch("custom_components.cuboai.tutk.cuboai_messages.CuboAIClient", return_value=client), \
+         patch("custom_components.cuboai.tutk.cuboai_messages.build_set_lullaby_vol_duration", _build):
+        media_player._execute_lullaby_cmd(
+            "uid", "acct", "pw", "192.0.2.10", "play", "SOME-UUID", volume, timer
+        )
+    return seen
+
+
+def test_play_keeps_the_cameras_volume_when_none_is_supplied():
+    """Both callers pass volume=None; play must not silently reset it to 50."""
+    seen = _run_play_cmd(volume=None, timer=None, sched_volume=70)
+    assert seen["volume"] == 70
+
+
+def test_play_honours_an_explicit_volume():
+    seen = _run_play_cmd(volume=20, timer=None, sched_volume=70)
+    assert seen["volume"] == 20
+
+
+def test_play_with_no_timer_is_repeat_forever():
+    """The card path relies on this: HA enforces the duration and sends the stop."""
+    seen = _run_play_cmd(volume=None, timer=None)
+    assert seen["timer"] == 0
+
+
+def test_play_converts_minutes_to_the_cameras_seconds_encoding():
+    seen = _run_play_cmd(volume=None, timer=30)
+    assert seen["timer"] == 1800

--- a/tests/test_night_light_brightness.py
+++ b/tests/test_night_light_brightness.py
@@ -90,3 +90,27 @@ def test_entity_reports_unknown_rather_than_a_hardcoded_hundred():
 
 def test_entity_does_not_round_a_real_hundred_away():
     assert _entity({"brightness": 100}).native_value == 100
+
+
+# --- the Status LED switch read a key the poll never wrote -------------------
+
+import custom_components.cuboai.switch as switch_mod  # noqa: E402
+
+
+def _led(local):
+    e = object.__new__(switch_mod.CuboStatusLEDSwitch)
+    e.coordinator = MagicMock()
+    e.coordinator.data = {"cameras": {DEVICE: {"local": local}}}
+    e._device_id = DEVICE
+    return e
+
+
+def test_status_led_reflects_the_polled_camera_value():
+    """The poll writes `status_light_on`; the switch used to read `status_led_on`,
+    which nothing wrote, so it sat at False no matter what the camera reported."""
+    assert _led({"status_light_on": True}).is_on is True
+    assert _led({"status_light_on": False}).is_on is False
+
+
+def test_status_led_defaults_to_off_when_the_poll_has_no_value():
+    assert _led({}).is_on is False

--- a/tests/test_night_light_brightness.py
+++ b/tests/test_night_light_brightness.py
@@ -1,0 +1,92 @@
+"""Night-light brightness must come from the camera, not a constant.
+
+`local["brightness"]` was READ in two places — the Night Light Brightness number
+and the light entity's `brightness` property — and WRITTEN in none. Nothing in
+the integration called GET_LIGHT_STYLE, so the key never existed:
+
+  * the number returned its hardcoded fallback of 100 no matter what the camera
+    was set to (observed live: the entity sat at exactly 100);
+  * the light entity returned None for brightness while advertising
+    ColorMode.BRIGHTNESS.
+
+The camera reports it on GET_LIGHT_STYLE at offset 24 (percent), a read-back
+that round-trips correctly in both directions. The coordinator now polls it, and
+the number reports unknown rather than a constant when it has no value.
+
+Same shape as the lullaby-timer defect: an entity presenting a local guess as if
+it were camera state.
+"""
+
+import importlib
+import importlib.util
+import os
+import struct
+import sys
+from unittest.mock import MagicMock, patch
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+sys.modules.pop("custom_components.cuboai.coordinator", None)
+coordinator = importlib.import_module("custom_components.cuboai.coordinator")
+number = importlib.import_module("custom_components.cuboai.number")
+
+GET_LIGHT_STYLE_REQ = 4366
+DEVICE = "SW05TESTDEVICE01"
+
+
+def _light_style_response(brightness):
+    raw = bytearray(64)
+    struct.pack_into("<i", raw, 24, brightness)
+    return bytes(raw)
+
+
+def _fetch(brightness=None, raises=False):
+    """Run _fetch_local_data with a session that answers GET_LIGHT_STYLE."""
+    def _ioctl(op, payload=b""):
+        if op == GET_LIGHT_STYLE_REQ:
+            if raises:
+                raise RuntimeError("timeout")
+            return op + 1, _light_style_response(brightness)
+        return op + 1, bytes(64)
+
+    sess = MagicMock()
+    sess.ioctl.side_effect = _ioctl
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=sess)
+    ctx.__exit__ = MagicMock(return_value=False)
+    with patch("custom_components.cuboai.tutk.cuboai_session.get_session", return_value=ctx), \
+         patch("custom_components.cuboai.tutk.cuboai_messages.CuboAIClient", return_value=MagicMock()):
+        return coordinator._fetch_local_data("uid", "acct", "pw", "192.0.2.10")
+
+
+def test_the_poll_now_reports_the_cameras_brightness():
+    assert _fetch(brightness=3)["brightness"] == 3
+
+
+def test_a_different_brightness_is_reported_verbatim():
+    assert _fetch(brightness=78)["brightness"] == 78
+
+
+def test_a_failed_read_leaves_the_key_unset_so_the_last_value_carries():
+    assert "brightness" not in _fetch(raises=True)
+
+
+def _entity(local):
+    e = object.__new__(number.CuboNightLightBrightnessNumber)
+    e.coordinator = MagicMock()
+    e.coordinator.data = {"cameras": {DEVICE: {"local": local}}}
+    e._device_id = DEVICE
+    return e
+
+
+def test_entity_reports_the_cameras_value():
+    assert _entity({"brightness": 3}).native_value == 3
+
+
+def test_entity_reports_unknown_rather_than_a_hardcoded_hundred():
+    """The bug: with no value at all the entity used to claim 100."""
+    assert _entity({}).native_value is None
+
+
+def test_entity_does_not_round_a_real_hundred_away():
+    assert _entity({"brightness": 100}).native_value == 100

--- a/tests/test_set_readback.py
+++ b/tests/test_set_readback.py
@@ -17,34 +17,12 @@ import importlib.util
 import logging
 import os
 import sys
-import types
 from unittest.mock import MagicMock, patch
 
 _ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-
-def _stub(name, **attrs):
-    """Register a stub module. conftest mocks `homeassistant` itself, which makes it
-    a non-package, so every submodule switch.py imports has to be registered here —
-    and the entity base classes must be real classes, not MagicMock attributes."""
-    mod = types.ModuleType(name)
-    for k, v in attrs.items():
-        setattr(mod, k, v)
-    sys.modules[name] = mod
-    return mod
-
-
-def _base(name):
-    """A distinct stand-in class per Home Assistant entity base — they are combined
-    by multiple inheritance, so they must not collapse into one shared class."""
-    return type(name, (), {"__init__": lambda self, *a, **k: None})
-
-
-_stub("homeassistant.components")
-_stub("homeassistant.components.switch", SwitchEntity=_base("SwitchEntity"))
-_stub("homeassistant.helpers.restore_state", RestoreEntity=_base("RestoreEntity"))
-_stub("homeassistant.helpers.update_coordinator", CoordinatorEntity=_base("CoordinatorEntity"))
-_stub("homeassistant.exceptions", HomeAssistantError=RuntimeError)
+# The Home Assistant entity bases come from conftest, which registers real stub
+# classes for them. Only the utils swap is specific to this module.
 
 # conftest replaces custom_components.cuboai.utils with a MagicMock, which would
 # turn the @retry_camera_command-decorated helpers into mocks too. Put the real

--- a/tests/test_set_readback.py
+++ b/tests/test_set_readback.py
@@ -1,0 +1,149 @@
+"""A SET the camera acknowledges but ignores must not be reported as applied.
+
+`baby_presence_alert` is one of four coupled fields in SET_SLEEP_SAFETY_SETTING
+that this camera firmware accepts (`result=0`) and then does not apply. A live
+round-trip showed its read-back unchanged in both directions while
+`safety_alert`, `cover_alert` and `sensitivity` read back exactly as written in
+the same call, so it is the field being ignored, not the transport.
+
+The switch used to write the REQUESTED value straight into the coordinator
+cache, so Home Assistant showed a state the camera was not in until the next
+poll quietly reverted it. On a baby monitor's presence alert that is the wrong
+thing to be quiet about. It now reads the value back and publishes the truth.
+"""
+
+import importlib
+import importlib.util
+import logging
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _stub(name, **attrs):
+    """Register a stub module. conftest mocks `homeassistant` itself, which makes it
+    a non-package, so every submodule switch.py imports has to be registered here —
+    and the entity base classes must be real classes, not MagicMock attributes."""
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _base(name):
+    """A distinct stand-in class per Home Assistant entity base — they are combined
+    by multiple inheritance, so they must not collapse into one shared class."""
+    return type(name, (), {"__init__": lambda self, *a, **k: None})
+
+
+_stub("homeassistant.components")
+_stub("homeassistant.components.switch", SwitchEntity=_base("SwitchEntity"))
+_stub("homeassistant.helpers.restore_state", RestoreEntity=_base("RestoreEntity"))
+_stub("homeassistant.helpers.update_coordinator", CoordinatorEntity=_base("CoordinatorEntity"))
+_stub("homeassistant.exceptions", HomeAssistantError=RuntimeError)
+
+# conftest replaces custom_components.cuboai.utils with a MagicMock, which would
+# turn the @retry_camera_command-decorated helpers into mocks too. Put the real
+# module back before loading switch.py so the helpers under test are real.
+_utils_path = os.path.join(_ROOT, "custom_components", "cuboai", "utils.py")
+_uspec = importlib.util.spec_from_file_location("custom_components.cuboai.utils", _utils_path)
+_utils = importlib.util.module_from_spec(_uspec)
+sys.modules["custom_components.cuboai.utils"] = _utils
+_uspec.loader.exec_module(_utils)
+
+sys.modules.pop("custom_components.cuboai.switch", None)
+switch = importlib.import_module("custom_components.cuboai.switch")
+
+
+class _FakeEntity:
+    """The attributes _apply_verified touches on a real switch entity."""
+
+    def __init__(self):
+        self.coordinator = MagicMock()
+        self.coordinator.data = {"cameras": {}}
+        self._device_id = "SW05TESTDEVICE01"
+        self.entity_id = "switch.test_baby_presence"
+        self._attr_name = "Test Baby Presence"
+        self.written = 0
+
+    def async_write_ha_state(self):
+        self.written += 1
+
+
+def _cached(entity, key):
+    return entity.coordinator.data["cameras"][entity._device_id]["local"][key]
+
+
+def test_applied_value_is_published_when_the_camera_honours_it(caplog=None):
+    e = _FakeEntity()
+    switch._apply_verified(e, "baby_presence", True, True, "the baby-presence alert")
+    assert _cached(e, "baby_presence") is True
+    assert e.written == 1
+
+
+def test_ignored_set_publishes_the_cameras_real_state_not_the_request():
+    e = _FakeEntity()
+    switch._apply_verified(e, "baby_presence", True, False, "the baby-presence alert")
+    assert _cached(e, "baby_presence") is False, "the requested value must not be published"
+    assert e.written == 1
+
+
+def test_ignored_set_warns_once_not_on_every_toggle(caplog):
+    caplog.set_level(logging.WARNING)
+    e = _FakeEntity()
+    for _ in range(4):
+        switch._apply_verified(e, "baby_presence", True, False, "the baby-presence alert")
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1, f"expected exactly one warning, got {len(warnings)}"
+    assert "does not apply it" in warnings[0].getMessage()
+
+
+def test_honoured_set_does_not_warn(caplog):
+    caplog.set_level(logging.WARNING)
+    e = _FakeEntity()
+    switch._apply_verified(e, "baby_presence", False, False, "the baby-presence alert")
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+
+def _session_ctx(client):
+    """A get_session(...) context manager whose session exposes .ioctl."""
+    sess = MagicMock()
+    sess.ioctl.return_value = (0, b"\x00" * 24)
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=sess)
+    ctx.__exit__ = MagicMock(return_value=False)
+    return ctx, sess
+
+
+def test_baby_presence_helper_returns_the_readback_not_the_request():
+    client = MagicMock()
+    client.get_sleep_safety_status.return_value = {"baby_presence_alert": False}
+    ctx, sess = _session_ctx(client)
+    with patch("custom_components.cuboai.tutk.cuboai_session.get_session", return_value=ctx), \
+         patch("custom_components.cuboai.tutk.cuboai_messages.CuboAIClient", return_value=client), \
+         patch("custom_components.cuboai.tutk.cuboai_messages.build_get_sleep_safety_setting",
+               return_value=(0x2331, b"")), \
+         patch("custom_components.cuboai.tutk.cuboai_messages.build_set_sleep_safety_setting",
+               return_value=(0x2332, b"")):
+        got = switch._set_baby_presence("uid", "acct", "pw", "192.0.2.10", True)
+    assert got is False, "helper must report the camera's value, not the requested one"
+    client.get_sleep_safety_status.assert_called_once()
+
+
+def test_readback_failure_falls_back_to_the_requested_value():
+    """A failed read-back is not a failed SET — don't invent an 'unknown' state."""
+    client = MagicMock()
+    client.get_sleep_safety_status.side_effect = RuntimeError("timeout")
+    ctx, sess = _session_ctx(client)
+    with patch("custom_components.cuboai.tutk.cuboai_session.get_session", return_value=ctx), \
+         patch("custom_components.cuboai.tutk.cuboai_messages.CuboAIClient", return_value=client), \
+         patch("custom_components.cuboai.tutk.cuboai_messages.build_get_sleep_safety_setting",
+               return_value=(0x2331, b"")), \
+         patch("custom_components.cuboai.tutk.cuboai_messages.build_set_sleep_safety_setting",
+               return_value=(0x2332, b"")):
+        got = switch._set_baby_presence("uid", "acct", "pw", "192.0.2.10", True)
+    assert got is True

--- a/tests/test_tail_swap.py
+++ b/tests/test_tail_swap.py
@@ -1,0 +1,110 @@
+"""The TransCodePartial tail `Swap` must be applied on the data channel.
+
+`custom_components/cuboai/tutk/cuboai_pure.py` (the engine every LIVE surface
+uses — streaming, talkback, and every IOCTL GET/SET behind the switches,
+selects, lights, numbers and the coordinator poll) carried an older revision of
+`transcode`/`inv_transcode` that treated the partial-block tail as a plain XOR
+and explicitly warned against re-adding the `Swap` permutation.
+
+That is wrong for the data channel. Native TUTK applies `Swap` to the tail for
+tail lengths 2/4/8 (identity everywhere else), so every data-channel frame whose
+length & 0xF is 2, 4 or 8 was built and parsed with a mangled tail — e.g. the
+216-byte lullaby-schedule SET (tail 8), whose duration field lives in the tail.
+
+`custom_components/cuboai/tutk/playback_engine/cuboai_pure.py` — the copy the
+DVR playback process already ships — has the corrected implementation, verified
+byte-for-byte against the native library via ctypes. It is used here as the
+oracle: the two copies must now agree exactly.
+"""
+
+import importlib.util
+import os
+import random
+
+_TUTK = os.path.join(os.path.dirname(__file__), "..", "custom_components", "cuboai", "tutk")
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+live = _load("live_pure", os.path.join(_TUTK, "cuboai_pure.py"))
+oracle = _load("oracle_pure", os.path.join(_TUTK, "playback_engine", "cuboai_pure.py"))
+
+
+def _samples():
+    rnd = random.Random(20260903)
+    for n in range(0, 97):
+        yield bytes(rnd.randrange(256) for _ in range(n))
+    for n in (216, 598, 88, 76, 52, 24):  # real frame sizes on this protocol
+        yield bytes(rnd.randrange(256) for _ in range(n))
+
+
+def test_tail_swap_helper_matches_oracle():
+    assert live._TAIL_SWAP == oracle._TAIL_SWAP
+    for length in range(0, 17):
+        buf = bytes(range(length))
+        assert live._tail_swap(buf, length) == oracle._tail_swap(buf, length)
+
+
+def test_tail_swap_is_an_involution():
+    for length in (2, 4, 8):
+        buf = bytes(range(length))
+        assert live._tail_swap(live._tail_swap(buf, length), length) == buf
+
+
+def test_transcode_matches_oracle_byte_for_byte():
+    for plain in _samples():
+        assert live.transcode(plain) == oracle.transcode(plain), f"len={len(plain)}"
+        assert live.transcode(plain, swap_tail=False) == oracle.transcode(plain, swap_tail=False)
+
+
+def test_inv_transcode_matches_oracle_byte_for_byte():
+    for wire in _samples():
+        assert live.inv_transcode(wire) == oracle.inv_transcode(wire), f"len={len(wire)}"
+
+
+def test_round_trip_is_symmetric():
+    for plain in _samples():
+        assert live.inv_transcode(live.transcode(plain)) == plain, f"len={len(plain)}"
+
+
+def test_tail_2_4_8_actually_changed():
+    """Guard against a silent revert: for tails 2/4/8 the new wire MUST differ
+    from the old plain-XOR encoding, otherwise the fix is not in effect."""
+    changed = 0
+    for plain in _samples():
+        n = len(plain)
+        tl = n & 0xF
+        full = n - tl
+        legacy = bytearray(live.transcode(plain))
+        for i in range(full, n):
+            legacy[i] = live._K16[i - full] ^ plain[i]  # rebuild the OLD tail
+        if tl in (2, 4, 8) and bytes(legacy[full:]) != live.transcode(plain)[full:]:
+            changed += 1
+    assert changed > 0, "tail Swap is not being applied — fix reverted?"
+
+
+def test_search_frames_are_unchanged_by_the_fix():
+    """The pre-session SEARCH/broadcast frames must keep the NO-Swap tail.
+
+    This is the exact regression the old docstring feared ("it corrupts the
+    probe tail and breaks connect"). Pinning them against the oracle proves the
+    data-channel fix does not touch the frames that establish the session.
+    """
+    uid = b"BRR9ZN8XT17UZBWT111A"
+    for R in (0x0000, 0x1234, 0xFFFF):
+        assert live.build_probe(uid, R) == oracle.build_probe(uid, R)
+        assert live.build_ack(uid, R) == oracle.build_ack(uid, R)
+        assert live.build_lan_query(uid, R) == oracle.build_lan_query(uid, R)
+        # 88-byte probe/ack have tail 8 — but as SEARCH frames they stay un-Swapped.
+        assert len(live.build_probe(uid, R)) & 0xF == 8
+
+
+if __name__ == "__main__":  # runnable without pytest
+    for fn in sorted(k for k in dict(globals()) if k.startswith("test_")):
+        globals()[fn]()
+        print("ok:", fn)

--- a/tests/test_talkback_resend_wrap.py
+++ b/tests/test_talkback_resend_wrap.py
@@ -1,0 +1,122 @@
+"""Talkback loss-recovery must keep resolving resend requests past the u16 wrap.
+
+Two-way talk (`cuboai_stream_backchannel.py` -> `send_audio`) keeps every frame
+it has sent in `sent_buf`, keyed by `talk_frag`. `talk_frag` is deliberately
+MONOTONIC and unbounded — it must not restart when a looped file wraps its
+content, or the camera rejects the replayed frames as already-seen.
+
+The camera's 0x09 resend request, however, names frames with a u16:
+`frag = (C + entry) & 0xFFFF`. Past 65536 frames — at 64 ms/frame that is about
+70 minutes of continuous or looping talkback — every `sent_buf.get(frag)`
+misses, and talkback loss-recovery silently stops. Nothing errors: the wire
+stays well-formed, `resends_sent` simply stops rising.
+
+The fix lifts the u16 BACKWARD into `talk_frag`'s space. A resend request always
+names a frame we already sent, so the nearest congruent value at-or-below the
+current frag is the right one. Below the wrap it is the identity.
+
+`tutk/playback_engine/cuboai_pure.py` already carries this; this pins the live
+copy. Same bug class as test_dataack_wrap.py.
+"""
+
+import importlib.util
+import os
+import re
+import struct
+
+_TUTK = os.path.join(os.path.dirname(__file__), "..", "custom_components", "cuboai", "tutk")
+_SRC = os.path.join(_TUTK, "cuboai_pure.py")
+
+_spec = importlib.util.spec_from_file_location("live_pure_talk", _SRC)
+cp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cp)
+
+
+def test_identity_below_the_wrap():
+    """Below 65536 the lift must change nothing, so existing wire behaviour is untouched."""
+    for cur in (0, 1, 999, 65535):
+        for idx in range(0, min(cur, 300) + 1):
+            assert cp._unwrap_index_back(idx, cur) == idx, (idx, cur)
+
+
+def test_resolves_across_the_wrap():
+    cur = 70000                       # ~74 min of talkback
+    # the camera asks for frame 69990, which on the wire is 69990 % 65536
+    assert cp._unwrap_index_back(69990 % 65536, cur) == 69990
+    # the frame right at the wrap boundary
+    assert cp._unwrap_index_back(65536 % 65536, cur) == 65536
+    # and the current frame itself
+    assert cp._unwrap_index_back(cur % 65536, cur) == cur
+
+
+def test_always_returns_a_value_at_or_below_cur():
+    """A resend always names an already-sent frame, so the lift must never point ahead."""
+    for cur in (0, 65535, 65536, 65537, 131071, 200000):
+        for wire in (0, 1, 32767, 32768, 65534, 65535):
+            got = cp._unwrap_index_back(wire, cur)
+            assert got <= cur, (wire, cur, got)
+            assert (got - wire) % 65536 == 0, (wire, cur, got)
+            assert cur - got < 65536, (wire, cur, got)
+
+
+def _sack(C, entries):
+    """A camera 0x09 resend-request frame: count at [42:44], C at [36:38], entries from [50:]."""
+    dec = bytearray(52 + 2 * len(entries))
+    struct.pack_into("<H", dec, 36, C & 0xFFFF)
+    struct.pack_into("<H", dec, 42, len(entries))
+    for i, e in enumerate(entries):
+        struct.pack_into("<H", dec, 50 + 2 * i, e & 0xFFFF)
+    return bytes(dec)
+
+
+def _lookup(dec, sent_buf, talk_frag, use_fix):
+    """The exact decode + lookup the SACK branch of send_audio performs."""
+    hits = []
+    cnt = struct.unpack_from("<H", dec, 42)[0]
+    C = struct.unpack_from("<H", dec, 36)[0]
+    if 0 < cnt < 256 and C != 0xFFFF:
+        for k in range(min(cnt, (len(dec) - 50) // 2)):
+            frag = (C + struct.unpack_from("<H", dec, 50 + 2 * k)[0]) & 0xFFFF
+            if use_fix:
+                frag = cp._unwrap_index_back(frag, talk_frag)
+            if sent_buf.get(frag) is not None:
+                hits.append(frag)
+    return hits
+
+
+def test_lookup_misses_without_the_fix_and_hits_with_it():
+    """The concrete failure: ~70 minutes in, the camera asks for three recent
+    frames and the legacy u16 lookup resolves none of them."""
+    talk_frag = 70000
+    sent_buf = dict.fromkeys(range(talk_frag - 128, talk_frag), b"au")   # the real 128-frame buffer
+    wanted = [69995, 69996, 69997]
+    C = wanted[0] & 0xFFFF
+    dec = _sack(C, [w - wanted[0] for w in wanted])
+
+    assert _lookup(dec, sent_buf, talk_frag, use_fix=False) == [], "legacy lookup should miss (the bug)"
+    assert _lookup(dec, sent_buf, talk_frag, use_fix=True) == wanted
+
+
+def test_lookup_is_unchanged_below_the_wrap():
+    talk_frag = 5000
+    sent_buf = dict.fromkeys(range(talk_frag - 128, talk_frag), b"au")
+    wanted = [4990, 4991]
+    dec = _sack(wanted[0], [w - wanted[0] for w in wanted])
+    assert _lookup(dec, sent_buf, talk_frag, use_fix=False) == wanted
+    assert _lookup(dec, sent_buf, talk_frag, use_fix=True) == wanted
+
+
+def test_source_still_applies_the_lift_at_the_lookup():
+    """Pin the call site: the model above only proves the arithmetic, so make sure
+    the shipped SACK branch actually performs the lift before sent_buf.get()."""
+    src = open(_SRC, encoding="utf-8").read()
+    m = re.search(r"frag = \(C \+ struct\.unpack_from.*?au = sent_buf\.get\(frag\)", src, re.S)
+    assert m, "the talkback SACK-replay lookup could not be located"
+    assert "_unwrap_index_back(frag, talk_frag)" in m.group(0), \
+        "the SACK-replay lookup no longer lifts the u16 into talk_frag's space"
+
+
+if __name__ == "__main__":
+    for fn in sorted(k for k in dict(globals()) if k.startswith("test_")):
+        globals()[fn]()
+        print("ok:", fn)


### PR DESCRIPTION
I've been running this integration for a while. I went looking for why the lullaby volume never matched my camera and found a cluster of related problems. 17 commits, each with tests, all measured on a live Cubo 3 camera.

The common shape: almost every camera read sits inside a broad except, and several have a plausible-looking constant as a fallback. When a read fails, the constant is indistinguishable from a real reading, so the failure is invisible, sometimes for a very long time.

## Silent read failures

- CuboAIClient.get_lullaby_schedule() does not exist, but coordinator.py calls it on every poll. AttributeError → swallowed → lullaby_volume = 50 fallback. A genuine volume of 50 looks identical. My camera was at 100 throughout. The builder, RESP constant and parse_lullaby_schedule were all already present and registered in GET_METHODS; only the wrapper was missing.
- local["brightness"] is read by two entities and written by nothing — nothing calls GET_LIGHT_STYLE. The Night Light Brightness number returned its hardcoded 100 regardless of the camera (mine is at 3%), and the light entity reported no brightness despite advertising ColorMode.BRIGHTNESS.
- The Status LED switch read status_led_on; the poll writes status_light_on. A wiring fix only — no claim about whether the LED obeys a SET.
- _extract_json used a greedy \{.*\}, spanning to the last } anywhere in the blob. These are binary frames with counters after the JSON, so a stray 0x7D broke the parse — the Connection Mode sensor dropped to unknown ~1 poll in 3 (200 times in 12 h).

## Coupled writes

SET_LULLABY_VOL_DURATION carries volume and timer in one struct, with no volume-only or timer-only opcode, so every write is necessarily a read-modify-write. Several call sites supplied one field and defaulted the other, so starting a lullaby reset the volume to 50, and changing the volume cancelled a running sleep timer. build_set_lullaby_schedule already existed as the RMW helper; the call sites now use it.

## Vendored-engine parity

tutk/ had drifted behind tutk/playback_engine/. Backported: the TransCodePartial tail Swap (mis-encodes any frame whose length mod 16 is 2/4/8 — affects the lullaby-schedule and sleep-safety SETs), two u16 wrap fixes, the mid-session reassembly seed, and a random AV-MID fallback.